### PR TITLE
Advanced Script examples + Duplicate mapping fix

### DIFF
--- a/Scripts/PublishingPageTransformation/AdvancedTransformPublishingPages.ps1
+++ b/Scripts/PublishingPageTransformation/AdvancedTransformPublishingPages.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+Transforms a set of publishing pages with the framework directly
+
+IMPORTANT: this requires the PnP PowerShell version 3.8.1904.0 (April 2019) or higher to work!
+Version: 1.0
+
+This script depends on two files:
+    Web Part Mapping file - to generate run: Export-PnPClientSidePageMapping -BuiltInWebPartMapping -Folder (Get-Location)
+    Page Layout mapping file - to generate run: AnalyseLayouts.ps1 (update the Url in the file first)
+
+.EXAMPLE
+PS C:\> .\AnalyseLayouts.ps1
+#>
+
+# Connect to the web holding the pages to modernize
+$creds = Get-Credential
+$sourceConnection = Connect-PnPOnline -Url https://contoso.sharepoint.com/sites/sourcemodernizationme -Credentials $creds -ReturnConnection
+$targetConnection = Connect-PnPOnline -Url https://contoso.sharepoint.com/sites/targetsite -Credentials $creds -ReturnConnection
+
+
+$layoutMappingFile = "$(Get-Location)\PageLayoutMapping.xml" # Run AnalyseLayouts.ps1 to get Mapping File
+$webPartMappingFile = "$(Get-Location)\webpartmapping.xml"
+
+# Get PnP Modules to find the modernisation assemblies
+$modules = (Get-Module -List "SharePointPnPPowerShellOnline")
+$modulePath = ""
+if($modules.Count -gt 0){
+    $latest = $modules[0]
+    $modulePath = $latest.ModuleBase
+    Write-Host "Found module: $($modulePath)"
+}else{
+    throw "Cannot find PnP Modules"
+}
+
+if($modulePath){
+
+    Add-Type -Path "$($modulePath)\SharePointPnP.Modernization.Framework.dll"
+
+    Write-Host "Transforming pages" -ForegroundColor Cyan
+
+    $pageTransformator = New-Object -TypeName SharePointPnP.Modernization.Framework.Publishing.PublishingPageTransformator `
+                            -ArgumentList $sourceConnection.Context, `
+                                          $targetConnection.Context, `
+                                          $webPartMappingFile, `
+                                          $layoutMappingFile
+    
+    # Generates a markdown report
+    $markdownObserver = `
+        New-Object -TypeName SharePointPnP.Modernization.Framework.Telemetry.Observers.MarkdownObserver -ArgumentList folder:"$(Get-Location)"                                       
+    $pageTransformator.RegisterObserver($markdownObserver);    
+ 
+    # Get Items from Pages Library
+    $pages = Get-PnPListItem -List "Pages" -Connection $sourceConnection
+    $pages | ForEach-Object{
+
+        # Options for the transformation engine
+        $pti = New-Object -TypeName SharePointPnP.Modernization.Framework.Publishing.PublishingPageTransformationInformation -ArgumentList $_
+        $pti.Overwrite = $true
+
+        Write-Host "Transforming page...$($_.FieldValues["FileLeafRef"])" -ForegroundColor Cyan 
+        $result = $pageTransformator.Transform($pti)
+        $pageTransformator.FlushObservers()
+
+        Write-Host "Transformed file $($result)" -ForegroundColor Green
+    }
+
+    $pageTransformator.FlushObservers()
+    
+    Write-Host "Done :-)" -ForegroundColor Green
+
+}else{
+    Write-Error "Cannot find the transformation modules"
+}

--- a/Scripts/PublishingPageTransformation/AnalyseLayouts.ps1
+++ b/Scripts/PublishingPageTransformation/AnalyseLayouts.ps1
@@ -1,0 +1,52 @@
+<#
+.SYNOPSIS
+Analyses a set of pages individually by publishing page
+
+IMPORTANT: this requires the PnP PowerShell version 3.8.1904.0 (April 2019) or higher to work!
+Version: 1.0
+
+.EXAMPLE
+PS C:\> .\AnalyseLayouts.ps1
+#>
+
+# Connect to the web holding the pages to modernize
+Connect-PnPOnline -Url https://contoso.sharepoint.com/sites/modernizationme
+
+$ctx = Get-PnPContext
+
+$modules = (Get-Module -List "SharePointPnPPowerShellOnline")
+$modulePath = ""
+if($modules.Count -gt 0){
+
+    $latest = $modules[0]
+    $modulePath = $latest.ModuleBase
+
+}else{
+    throw "Cannot find PnP Modules"
+}
+
+Write-Host "Found module: $($modulePath)"
+
+if($modulePath){
+
+    Add-Type -Path "$($modulePath)\SharePointPnP.Modernization.Framework.dll"
+
+    Write-Host "Analysing Layouts" -ForegroundColor Cyan
+
+    $pages = Get-PnPListItem -List "Pages"
+    $analyser = New-Object -TypeName SharePointPnP.Modernization.Framework.Publishing.PageLayoutAnalyser -ArgumentList $ctx
+
+    $pages | ForEach-Object{
+
+        Write-Host "Analysing layout"
+        $analyser.AnalysePageLayoutFromPublishingPage($_)
+
+    }
+
+    $analyser.GenerateMappingFile((Get-Location), "PageLayoutMapping.xml")
+
+    Write-Host "Done :-)" -ForegroundColor Green
+
+}else{
+    Write-Error "Cannot find the transformation modules"
+}

--- a/Scripts/PublishingPageTransformation/readme.md
+++ b/Scripts/PublishingPageTransformation/readme.md
@@ -1,0 +1,36 @@
+# Scripts related to transforming Publishing pages using PowerShell
+
+## Summary
+
+The page transformation engine can also be used from PowerShell. This allows collection of scripts perform operations related to publishing pages transformation, giving you full access to the objects and options.
+
+## Applies to
+
+- Office 365 Multi-Tenant (MT)
+
+## Prerequisites
+
+- SharePoint PnP PowerShell version 3.8.1904.0 or higher (April 2019)
+
+## Solution
+
+Solution|Author(s)
+--------|---------
+AnalyseLayouts.ps1 | Paul Bullock (**CaPa Creative Ltd**)
+AdvancedTransformPublishingPages.ps1 | Paul Bullock (**CaPa Creative Ltd**)
+
+## Version history
+
+Version|Date|Comments
+-------|----|--------
+1.0 | April 8th 2019 | Initial commit
+
+## Disclaimer
+
+THIS CODE IS PROVIDED AS IS WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANT ABILITY, OR NON-INFRINGEMENT.
+
+---
+
+## Learn more about using PowerShell to modernize pages
+
+Checkout the [Transforming to modern site pages using PowerShell](https://docs.microsoft.com/en-us/sharepoint/dev/transform/modernize-userinterface-site-pages-powershell) article on docs.microsoft.com.

--- a/Scripts/readme.md
+++ b/Scripts/readme.md
@@ -9,3 +9,4 @@ O365GroupConnect | Contains scripts that show how to perform a bulk Office 365 G
 PageTransformation | Holds scripts that can be used to modernize classic wiki and web part pages
 ModernizeSiteCollection | End to end modernization scripts that show how to fully modernize a site collection
 ListAndLibraries | Scripts to configure modern lists and libraries
+PublishingPageTransformation | Scripts to perform operations to transform publishing pages with the engine directly

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PageLayoutAnalyser.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PageLayoutAnalyser.cs
@@ -172,7 +172,13 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                 if (_mapping.PageLayouts != null)
                 {
                     var expandMappings = _mapping.PageLayouts.ToList();
-                    expandMappings.Add(layoutMapping);
+
+                    // Prevent duplicate references to the same page layout
+                    if (!expandMappings.Any(o => o.Name == layoutMapping.Name))
+                    {
+                        expandMappings.Add(layoutMapping);
+                    }
+
                     _mapping.PageLayouts = expandMappings.ToArray();
                 }
                 else


### PR DESCRIPTION
Added publishing page examples - outside the PnP PowerShell provided examples for advanced use

Also, related to #102  if others encounters difficulty, run the AnalyseLayouts.ps1 script to bypass the AnalyseAll method.

Related to #100 - filter the mapping where the layouts are duplicated when calling AnalysePageLayoutFromPublishingPage method.
