### PR TITLE
Fix for #107 bug - CDATA stripping

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Provision/Publishing/ArticleCustom.aspx
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Provision/Publishing/ArticleCustom.aspx
@@ -49,7 +49,7 @@
                     <FrameType>None</FrameType>
 					<PartImageLarge>/_layouts/15/images/mscontl.gif</PartImageLarge>
 					<ID>g_db666743_4c5b_4a21_a9cf_7a199ce19a60</ID>
-					<Content xmlns="http://schemas.microsoft.com/WebPart/v2/ContentEditor"><![CDATA[Welcome to the home of all SharePoint modernization tools and solutions. Modernization means transforming current "classic" SharePoint usage into "modern" usage, e.g. using modern site pages instead of classic wiki pages or Office 365 Group connecting of classic sites. In this repository you'll find all the SharePoint PnP open source scripts, tools and solutions that will help you modernize your SharePoint environment.]]></Content>
+					<Content xmlns="http://schemas.microsoft.com/WebPart/v2/ContentEditor"><![CDATA[<p>Welcome to the home of all SharePoint modernization tools and solutions. Modernization means transforming current <em>"classic"</em> SharePoint usage into "modern" usage, e.g. using modern site pages instead of classic wiki pages or Office 365 Group connecting of classic sites.</p> <p>In this repository you'll find all the SharePoint PnP open source scripts, tools and solutions that will help you modernize your <strong>SharePoint</strong> environment.</p>]]></Content>
 				</WebPart>
 			</WebPartPages:ContentEditorWebPart>
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPage.cs
@@ -258,7 +258,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
                         ZoneIndex = 0,
                         IsClosed = GetFixedWebPartProperty<bool>(fixedWebpart, "__designer:IsClosed", false),
                         Hidden = false,
-                        Properties = CastAsPropertiesDictionary(fixedWebpart),
+                        Properties = CastAsPropertiesDictionary(fixedWebpart, true),
                     });
 
                 }
@@ -297,13 +297,14 @@ namespace SharePointPnP.Modernization.Framework.Pages
             return defaultValue;
         }
 
-        private Dictionary<string, string> CastAsPropertiesDictionary(FixedWebPart webPart)
+        private Dictionary<string, string> CastAsPropertiesDictionary(FixedWebPart webPart, bool decodeValues = false)
         {
             Dictionary<string, string> props = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
             foreach(var prop in webPart.Property)
             {
-                props.Add(prop.Name, prop.Value);
+                props.Add(prop.Name,
+                    decodeValues ? System.Web.HttpUtility.HtmlDecode(prop.Value) : prop.Value);
             }
 
             return props;


### PR DESCRIPTION
This one is difficult to cleanly fix. AngleSharp, doesn't process some of the XML elements in a suitable way for XML, and thus adds some extra text in the CDATA Tag.

I had considered using AngleSharp.Xml, but this is dependant on 0.11.X which doesn't support the version of the .Net framework we are using. Ideally I would have liked to use this to assist in proper parsing of CDATA values but is likely to be a more substantial change.

Light testing is done based on some limited info, please test with your scenario if you already have one setup.

Related to #107 