### PR TITLE
Added block item level permissions cross-farm

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Utility/StringExtensionTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Utility/StringExtensionTests.cs
@@ -87,5 +87,53 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.Utility
 
             Assert.AreEqual(expectedResult, result);
         }
+
+        [TestMethod]
+        public void StringExtension_GetBaseUrlValidHttpsString()
+        {
+
+            var input = "https://server/pnptransformationsource/en/pages/search.aspx";
+            var expectedResult = "https://server";
+
+            var result = input.GetBaseUrl();
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public void StringExtension_GetBaseUrlValidHttpString()
+        {
+
+            var input = "http://server/pnptransformationsource/en/pages/search.aspx";
+            var expectedResult = "http://server";
+
+            var result = input.GetBaseUrl();
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public void StringExtension_GetBaseUrlInvalidString()
+        {
+
+            var input = "/pnptransformationsource/en/pages/search.aspx";
+            var expectedResult = string.Empty;
+
+            var result = input.GetBaseUrl();
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public void StringExtension_GetBaseUrEmptyString()
+        {
+
+            var input = string.Empty;
+            var expectedResult = string.Empty;
+
+            var result = input.GetBaseUrl();
+
+            Assert.AreEqual(expectedResult, result);
+        }
     }
 }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Extensions/StringExtensions.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Extensions/StringExtensions.cs
@@ -72,5 +72,29 @@ namespace SharePointPnP.Modernization.Framework.Extensions
             return value;
         }
 
+        /// <summary>
+        /// Gets base url from string
+        /// </summary>
+        /// <param name="sourceSite"></param>
+        /// <returns></returns>
+        public static string GetBaseUrl(this string url)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(url) && (url.ContainsIgnoringCasing("https://") || url.ContainsIgnoringCasing("http://")))
+                {
+                    Uri siteUri = new Uri(url);
+                    string host = $"{siteUri.Scheme}://{siteUri.DnsSafeHost}";
+                    return host;
+                }
+            }
+            catch (Exception)
+            {
+                //Swallow
+            }
+
+            return string.Empty;
+        }
+
     }
 }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageTransformator.cs
@@ -136,6 +136,10 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                 LogError(LogStrings.Error_PageIsNotAPublishingPage, LogStrings.Heading_InputValidation);
                 throw new ArgumentException(LogStrings.Error_PageIsNotAPublishingPage);
             }
+
+            // Disable cross-farm item level permissions from copying
+            EnsureItemLevelPermissionsContextsSupported(publishingPageTransformationInformation);
+
             LogDebug(LogStrings.ValidationChecksComplete, LogStrings.Heading_InputValidation);
             #endregion
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/LogStrings.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/LogStrings.cs
@@ -89,6 +89,8 @@
 
         public const string Warning_NonCriticalErrorDuringVersionStampAndPublish = "Page could not be published as versioning is not enabled or version stamp could not be set.";
 
+        public const string Warning_ContextValidationFailWithKeepPermissionsEnabled = "Keep Specific Permissions was set, however this is not currently supported when contexts are cross-farm/tenant - this feature has been disabled";
+
         #endregion
 
         #region Status Messages

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/BasePageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/BasePageTransformator.cs
@@ -4,6 +4,7 @@ using Microsoft.SharePoint.Client.Taxonomy;
 using OfficeDevPnP.Core.Pages;
 using SharePointPnP.Modernization.Framework.Cache;
 using SharePointPnP.Modernization.Framework.Entities;
+using SharePointPnP.Modernization.Framework.Extensions;
 using SharePointPnP.Modernization.Framework.Telemetry;
 using System;
 using System.Collections.Generic;
@@ -512,6 +513,31 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 clientContext.Load(clientContext.Site, p => p.RootWeb.ServerRelativeUrl, p => p.Id, p => p.Url);
                 // Use regular ExecuteQuery as we want to send this custom clienttag
                 clientContext.ExecuteQuery();
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the contexts are the same for the feature to be supported
+        /// </summary>
+        /// <param name="baseTransformationInformation">Transformation Information</param>
+        /// <remarks>Will disable feature if not supported</remarks>
+        internal void EnsureItemLevelPermissionsContextsSupported(BaseTransformationInformation baseTransformationInformation)
+        {
+            // Source only context - allow item level permissions
+            // Source to target same base address - allow item level permissions
+            // Source to target difference base address - disallow item level permissions
+
+            if(targetClientContext != null && sourceClientContext != null && baseTransformationInformation.KeepPageSpecificPermissions)
+            {
+                var sourceUrl = sourceClientContext.Url.GetBaseUrl();
+                var targetUrl = targetClientContext.Url.GetBaseUrl();
+
+                // Override the setting for keeping item level permissions
+                if(!sourceUrl.Equals(targetUrl, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    baseTransformationInformation.KeepPageSpecificPermissions = false;
+                    LogWarning(LogStrings.Warning_ContextValidationFailWithKeepPermissionsEnabled, LogStrings.Heading_InputValidation);
+                }
             }
         }
         #endregion

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -208,6 +208,9 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 }
             }
 
+            // Disable cross-farm item level permissions from copying
+            EnsureItemLevelPermissionsContextsSupported(pageTransformationInformation);
+
             LogDebug(LogStrings.ValidationChecksComplete, LogStrings.Heading_InputValidation);
 
             #endregion


### PR DESCRIPTION
- Add a check in the validation to prevent item level permissions where the URL base addresses are different indicating these environments are different farms/tenants.
- Added tests
- Added logging to show a warning that the setting was overridden

Related to issue #173 
