### PR TITLE
Support for multiple Field "name" values, and @Name token values in Functions.

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharePointPnP.Modernization.Framework.Tests</RootNamespace>
     <AssemblyName>SharePointPnP.Modernization.Framework.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -42,6 +42,9 @@
   <ItemGroup>
     <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient, Version=2.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.1.0\lib\portable-net4+sl5+win+wpa+wp8\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
@@ -138,6 +141,9 @@
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.12.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.12.0\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -147,6 +153,9 @@
     </Reference>
     <Reference Include="SharePointPnP.IdentityModel.Extensions, Version=1.2.4.0, Culture=neutral, PublicKeyToken=5e633289e95c321a, processorArchitecture=MSIL">
       <HintPath>..\packages\SharePointPnP.IdentityModel.Extensions.1.2.4\lib\net45\SharePointPnP.IdentityModel.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="SharePointPnP.Modernization.Framework.Fakes">
+      <HintPath>FakesAssemblies\SharePointPnP.Modernization.Framework.Fakes.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -161,6 +170,9 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -179,6 +191,9 @@
     <Reference Include="System.Spatial, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.8.4\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -191,7 +206,9 @@
     <Compile Include="Transform\OnPremises\OnPremisesPublishingPageTests.cs" />
     <Compile Include="Transform\Publishing\AdHocTests.cs" />
     <Compile Include="Transform\Publishing\PageLayoutAnalyserTests.cs" />
+    <Compile Include="Transform\Publishing\PublishingFunctionProcessorTests.cs" />
     <Compile Include="Transform\Publishing\PublishingPageTests.cs" />
+    <Compile Include="Transform\Publishing\PublishingPageTransformationInformationTests.cs" />
     <Compile Include="Transform\ReportingTests.cs" />
     <Compile Include="Transform\ContextTests.cs" />
     <Compile Include="Transform\Utility\StringExtensionTests.cs" />
@@ -213,9 +230,7 @@
     <Compile Include="Transform\Wp\WpTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="App.config.sample" />
     <None Include="packages.config" />
     <None Include="Provision\Documents\Contoso_Report.pptx" />
@@ -318,6 +333,7 @@
       <Name>SharePointPnP.Modernization.Framework</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharePointPnP.Modernization.Framework.Tests</RootNamespace>
     <AssemblyName>SharePointPnP.Modernization.Framework.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Publishing/PublishingFunctionProcessorTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Publishing/PublishingFunctionProcessorTests.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharePointPnP.Modernization.Framework.Publishing;
+using Moq;
+using Microsoft.SharePoint.Client;
+using SharePointPnP.Modernization.Framework.Transform;
+using System;
+
+namespace SharePointPnP.Modernization.Framework.Tests.Transform.Publishing
+{
+    [TestClass]
+    public class PublishingFunctionProcessorTests
+    {
+        public string ExpectedPropertyName = "Title";
+
+        [TestMethod]
+        public void ResolveFunctionToken_SimpleReplacementTest()
+        {
+            // Arrange
+            var funcProc = new PublishingFunctionProcessor(null, null, null, null, null, null);
+            // use nothing other than the token as the input function
+            string functionString = funcProc.NameAttributeToken;
+
+            // Act
+            string newFunction = funcProc.ResolveFunctionToken(functionString, ExpectedPropertyName);
+
+            // Assert
+            Assert.AreEqual(ExpectedPropertyName, newFunction);
+        }
+
+        [TestMethod]
+        public void ResolveFunctionToken_CaseSensitivityTest()
+        {
+            // Arrange
+            var funcProc = new PublishingFunctionProcessor(null, null, null, null, null, null);
+            // use nothing other than the token as the input function
+            string functionStringLower = funcProc.NameAttributeToken.ToLower();
+            string functionStringUpper = funcProc.NameAttributeToken.ToUpper();
+
+            // Act
+            string newFunctionLower = funcProc.ResolveFunctionToken(functionStringLower, ExpectedPropertyName);
+            string newFunctionUpper = funcProc.ResolveFunctionToken(functionStringUpper, ExpectedPropertyName);
+
+            // Assert
+            Assert.AreEqual(ExpectedPropertyName, newFunctionLower);
+            Assert.AreEqual(ExpectedPropertyName, newFunctionUpper);
+        }
+
+        [TestMethod]
+        public void ResolveFunctionToken_MultipleOccurencesTest()
+        {
+            // Arrange
+            var funcProc = new PublishingFunctionProcessor(null, null, null, null, null, null);
+            // use nothing other than the token as the input function
+
+            var templateString = "A='{0}';B='{1}';C='{2}'";
+            
+            // enter the token value in a multitude of formats
+            string inputFunctionString = string.Format(templateString,
+                funcProc.NameAttributeToken,
+                funcProc.NameAttributeToken.ToUpper(),
+                funcProc.NameAttributeToken.ToLower());
+
+            // get our expected output .. where all tokens are resolved to our "property name"
+            string expectedOutput = string.Format(templateString,
+                ExpectedPropertyName, ExpectedPropertyName, ExpectedPropertyName);
+
+
+            // Act
+            // do our token resolution
+            string newFunction = funcProc.ResolveFunctionToken(inputFunctionString, ExpectedPropertyName);
+
+            // Assert
+            // check the processed string matches our expected output
+            Assert.AreEqual(expectedOutput, newFunction);
+        }
+
+
+        [TestMethod]
+        public void ResolveFunctionToken_WithoutTokens()
+        {
+            // Arrange
+            var funcProc = new PublishingFunctionProcessor(null, null, null, null, null, null);
+            // use nothing other than the token as the input function
+
+            var functionString = "A='foo'";
+
+            // Act
+            // if this throws any exceptions the test will fail
+            string newFunction = funcProc.ResolveFunctionToken(functionString, ExpectedPropertyName);
+
+            // Assert
+            // make sure it hasn't changed
+            Assert.AreEqual(functionString, newFunction);
+        }
+    }
+
+}

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Publishing/PublishingPageTransformationInformationTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Publishing/PublishingPageTransformationInformationTests.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharePointPnP.Modernization.Framework.Publishing;
+using Moq;
+
+
+namespace SharePointPnP.Modernization.Framework.Tests.Transform.Publishing
+{
+    [TestClass]
+    public class PublishingPageTransformationInformationTests
+    {
+        string EmptyField = "EmptyField";
+        string FieldWithValue = "FieldWithValue";
+
+
+        [TestMethod]
+        public void GetGetFirstNonEmptyFieldName_EmptyArrayTest()
+        {
+            // Arrange
+            var ppti = new PublishingPageTransformationInformation(null);
+            string[] fieldNames = new string[0];
+
+            // Act
+            string fieldName = ppti.GetFirstNonEmptyFieldName(fieldNames);
+
+            // Assert
+            Assert.AreEqual(string.Empty, fieldName);
+        }
+
+        [TestMethod]
+        public void GetGetFirstNonEmptyFieldName_TrimTest()
+        {
+            // Arrange
+            var ppti = new PublishingPageTransformationInformation(null);
+            string[] fieldNames = new string[] {"   ","" };
+
+            // Act
+            string fieldName = ppti.GetFirstNonEmptyFieldName(fieldNames);
+
+            // Assert
+            Assert.AreEqual(string.Empty, fieldName);
+        }
+
+        [TestMethod]
+        public void GetGetFirstNonEmptyFieldName_RetrieveCorrectFieldTest()
+        {
+            // Arrange
+            #region Configure Mock
+            var mock = new Mock<PublishingPageTransformationInformation>
+            {
+                CallBase = true // <-- let mock call base members, except when "setup"
+            };
+
+            // hard coded results
+            mock.Setup(p => p.IsFieldUsed(EmptyField)).Returns(false);
+            mock.Setup(p => p.IsFieldUsed(FieldWithValue)).Returns(true);
+            #endregion
+            var ppti = mock.Object as PublishingPageTransformationInformation;
+            string[] fieldNames = new string[] { EmptyField, FieldWithValue };
+
+            // Act
+            string fieldName = ppti.GetFirstNonEmptyFieldName(fieldNames);
+
+            // Assert
+            Assert.AreEqual(FieldWithValue, fieldName);
+        }
+
+        [TestMethod]
+        public void GetGetFirstNonEmptyFieldName_FullTest()
+        {
+            // Arrange
+            #region Configure Mock
+            var mock = new Mock<PublishingPageTransformationInformation>
+            {
+                CallBase = true // <-- let mock call base members, except when "setup"
+            };
+
+            // hard coded results
+            mock.Setup(p => p.IsFieldUsed(EmptyField)).Returns(false);
+            mock.Setup(p => p.IsFieldUsed(FieldWithValue)).Returns(true);
+            #endregion
+            var ppti = mock.Object as PublishingPageTransformationInformation;
+            string[] fieldNames = new string[] { "", "   ", EmptyField, " " + FieldWithValue + "   " };
+
+            // Act
+            string fieldName = ppti.GetFirstNonEmptyFieldName(fieldNames);
+
+            // Assert
+            Assert.AreEqual(FieldWithValue, fieldName);
+        }
+    }
+}

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/packages.config
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net45" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.1.0" targetFramework="net45" />
@@ -16,16 +17,19 @@
   <package id="Microsoft.IdentityModel.Logging" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.SharePointOnline.CSOM" version="16.1.8924.1200" targetFramework="net45" />
+  <package id="Moq" version="4.12.0" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
   <package id="SharePointPnP.IdentityModel.Extensions" version="1.2.4" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.2.4" targetFramework="net461" />
   <package id="System.Net.Http" version="4.3.1" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Spatial" version="5.8.4" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
   <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net45" />
 </packages>

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingMetadataTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingMetadataTransformator.cs
@@ -76,6 +76,17 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                 // Copy the field metadata
                 foreach (var fieldToProcess in this.pageLayoutMappingModel.MetaData.Field)
                 {
+
+                    // check if the source field name attribute contains a delimiter value
+                    if(fieldToProcess.Name.Contains(";"))
+                    {
+                        // extract the array of field names to process, and trims each one
+                        string[] sourceFieldNames = fieldToProcess.Name.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+
+                        // sets the field name to the first "valid" entry
+                        fieldToProcess.Name = this.publishingPageTransformationInformation.GetFirstNonEmptyFieldName(sourceFieldNames);
+                    }
+
                     // Process only fields which have a target field set...
                     if (!string.IsNullOrEmpty(fieldToProcess.TargetFieldName))
                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageHeaderTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageHeaderTransformator.cs
@@ -160,6 +160,16 @@ namespace SharePointPnP.Modernization.Framework.Publishing
 
         private string GetFieldValue(HeaderField headerField, PublishingFunctionProcessor.FieldType fieldType = PublishingFunctionProcessor.FieldType.String)
         {
+            // check if the target field name contains a delimiter value
+            if (headerField.Name.Contains(";"))
+            {
+                // extract the array of field names to process, and trims each one
+                string[] targetFieldNames = headerField.Name.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+
+                // sets the field name to the first "valid" entry
+                headerField.Name = this.publishingPageTransformationInformation.GetFirstNonEmptyFieldName(targetFieldNames);
+            }
+
             string fieldValue = null;
             if (!string.IsNullOrEmpty(headerField.Functions))
             {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageTransformationInformation.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageTransformationInformation.cs
@@ -1,15 +1,26 @@
 ﻿using Microsoft.SharePoint.Client;
+using SharePointPnP.Modernization.Framework.Extensions;
 using SharePointPnP.Modernization.Framework.Transform;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SharePointPnP.Modernization.Framework.Publishing
 {
     /// <summary>
     /// Information used to configure the publishing page transformation process
     /// </summary>
-    public class PublishingPageTransformationInformation: BaseTransformationInformation
+    public class PublishingPageTransformationInformation : BaseTransformationInformation
     {
         #region Construction
+        /// <summary>
+        /// For internal use only
+        /// </summary>
+        public PublishingPageTransformationInformation() 
+        {
+            // constructor used exclusively for mocking
+        }
+
         /// <summary>
         /// Instantiates the page transformation class
         /// </summary>
@@ -39,6 +50,49 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                 { Constants.UseCommunityScriptEditorMappingProperty, "false" },
                 { Constants.SummaryLinksToQuickLinksMappingProperty, "true" }
             };
+        }
+        #endregion
+
+        #region Public Methods
+        /// <summary>
+        /// Given a collection of field names will return the first one which contains a value which is not null or empty.
+        /// </summary>
+        /// <param name="fieldNames">A array of Internal field names to check</param>
+        /// <returns>An Internal field name</returns>
+        public string GetFirstNonEmptyFieldName(string[] fieldNames)
+        {
+            // trim each entry before continuing
+            // and ignore empty or null values
+            fieldNames = fieldNames.Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+
+            string fieldNameToReturn = string.Empty;
+
+            foreach(string fieldName in fieldNames)
+            {
+                if(IsFieldUsed(fieldName))
+                {
+                    // use this field
+                    fieldNameToReturn = fieldName;
+                    break;
+                }
+            }
+
+            return fieldNameToReturn;
+        }
+
+        /// <summary>
+        /// Checks if a field is in use
+        /// </summary>
+        /// <param name="fieldName">Internal field name</param>
+        /// <returns>True or False</returns>
+        public virtual bool IsFieldUsed(string fieldName)
+        {
+            return this.SourcePage.FieldExistsAndUsed(fieldName);
+        }
+
+        public virtual bool AlwaysTrue()
+        {
+            return true;
         }
         #endregion
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/SharePointPnP.Modernization.Framework.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/SharePointPnP.Modernization.Framework.csproj
@@ -294,9 +294,7 @@
     <Compile Include="WebParts.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="PublishingPagesClassDiagram.cd" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -3,6 +3,7 @@ using OfficeDevPnP.Core.Pages;
 using OfficeDevPnP.Core.Utilities;
 using SharePointPnP.Modernization.Framework.Cache;
 using SharePointPnP.Modernization.Framework.Entities;
+using SharePointPnP.Modernization.Framework.Extensions;
 using SharePointPnP.Modernization.Framework.Pages;
 using SharePointPnP.Modernization.Framework.Telemetry;
 using System;

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Analyzers/PageAnalyzer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Analyzers/PageAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.SharePoint.Client;
 using SharePoint.Modernization.Scanner.Results;
 using SharePoint.Scanning.Framework;
+using SharePointPnP.Modernization.Framework.Extensions;
 
 namespace SharePoint.Modernization.Scanner.Analyzers
 {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Analyzers/PublishingAnalyzer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Analyzers/PublishingAnalyzer.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using System.Xml.XPath;
+using SharePointPnP.Modernization.Framework.Extensions;
 
 namespace SharePoint.Modernization.Scanner.Analyzers
 {


### PR DESCRIPTION
 1. Support for multiple field definitions (semi-colon separated values, will automatically handle erroneous whitespace).
 2. Support for {@Name} token values in Functions which refer to field mappings:

This will apply to the following elements in the "PageLayoutMapping.xml" files:
- PageLayout > Header > Field
- PageLayout > MetaData > Field

For example:
<Field Name="PublishingRollupImage;PublishingPageImage;PublishingPageContent" HeaderProperty="ImageServerRelativeUrl" Functions="ToImageUrl({@Name})" />

This will now check the three fields provided, in order:
1. Publishing Rollup Image
2. Publishing Page Image
3. Publishing Page Content

The first field which contains "any value" (i.e. the field both exists, and does not consist of an empty or null value) will be used.

The Function will replace {@Name} with the name of the property which is being used. 

This also works for single-property fields, for example;

<Field Name="PublishingContact" HeaderProperty="Authors" Functions="ToAuthors({@Name})" />

Here, you no longer need to repeat the "Name" attribute in the Functions section.
This both:

 - Avoids you from accidentally overriding the Name mapping in your function
 - Moves the focus to the "Name" attributes when scanning the file, to make scanning field elements with and without Function declarations consistent.