### PR TITLE
Fix for SharePoint 2010 and support Web Part Pages, Wiki Pages

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
@@ -205,6 +205,7 @@
   <ItemGroup>
     <Compile Include="TestExtensions.cs" />
     <Compile Include="Transform\OnPremises\OnPremisesPublishingPageTests.cs" />
+    <Compile Include="Transform\OnPremises\OnPremisesWebPartPageTests.cs" />
     <Compile Include="Transform\Publishing\AdHocTests.cs" />
     <Compile Include="Transform\Publishing\PageLayoutAnalyserTests.cs" />
     <Compile Include="Transform\Publishing\PublishingFunctionProcessorTests.cs" />

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
@@ -203,6 +203,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestExtensions.cs" />
     <Compile Include="Transform\OnPremises\OnPremisesPublishingPageTests.cs" />
     <Compile Include="Transform\Publishing\AdHocTests.cs" />
     <Compile Include="Transform\Publishing\PageLayoutAnalyserTests.cs" />

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/TestExtensions.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/TestExtensions.cs
@@ -16,7 +16,7 @@ namespace SharePointPnP.Modernization.Framework
         /// <param name="collection"></param>
         public static void FailTestIfZero(this ListItemCollection collection)
         {
-            if (collection.Count == 0)
+            if (collection == null || collection.Count == 0)
             {
                 Assert.Fail("No pages found");
             }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/TestExtensions.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/TestExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.SharePoint.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SharePointPnP.Modernization.Framework
+{
+    public static class TestExtensions
+    {
+        /// <summary>
+        /// Fail test if collection has no items
+        /// </summary>
+        /// <param name="collection"></param>
+        public static void FailTestIfZero(this ListItemCollection collection)
+        {
+            if (collection.Count == 0)
+            {
+                Assert.Fail("No pages found");
+            }
+        }
+    }
+}

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
@@ -175,7 +175,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                     //Should be one
                     TestBasePage testBase = new TestBasePage(page, page.File, null, null);
-                    var result = testBase.LoadWebPartPageFromWebServices(url);
+                    var result = testBase.LoadPublishingPageFromWebServices(url);
 
                     Assert.IsTrue(result.Count > 0);
 
@@ -205,7 +205,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                     //Should be one
                     TestBasePage testBase = new TestBasePage(page, page.File, null, null);
-                    var webPartEntities = testBase.LoadWebPartPageFromWebServices(url);
+                    var webPartEntities = testBase.LoadPublishingPageFromWebServices(url);
 
                     foreach (var webPart in webPartEntities)
                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SharePointPnP.Modernization.Framework.Tests.Transform.Publishing
+namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 {
     [TestClass]
     public class OnPremisesPublishingPageTests

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
@@ -27,9 +27,11 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.Publishing
                     pageTransformator.RegisterObserver(new UnitTestLogObserver());
 
                     //var pages = sourceClientContext.Web.GetPagesFromList("Pages", "Article-2010-Custom");
-                    var pages = sourceClientContext.Web.GetPagesFromList("Pages", "Article-2010-Custom-Test2");
+                    var pages = sourceClientContext.Web.GetPagesFromList("Pages", "ArticlePage-2010-Multiple");
                     //var pages = sourceClientContext.Web.GetPagesFromList("Pages", "Article-2010-Custom-Test3");
                     //var pages = sourceClientContext.Web.GetPagesFromList("Pages", folder:"News");
+
+                    pages.FailTestIfZero();
 
                     foreach (var page in pages)
                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
@@ -143,7 +143,8 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
                     TestBasePage testBase = new TestBasePage(page, page.File, null, null);
                     var result = testBase.ExtractWebPartDocumentViaWebServicesFromPage(url);
 
-                    Assert.IsTrue(result.Length > 0);
+                    Assert.IsTrue(result.Item1.Length > 0);
+                    Assert.IsTrue(result.Item2.Length > 0);
 
                     break;
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
@@ -109,7 +109,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
                     TestBasePage testBase = new TestBasePage(page, page.File, null, null);
                     var result = testBase.ExtractWebPartPropertiesViaWebServicesFromPage(url);
 
-                    Assert.IsTrue(result.Length > 0);
+                 Assert.IsTrue(result.Length > 0);
 
                     break;
 
@@ -117,6 +117,43 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
             }
 
         }
+
+        [TestMethod]
+        public void BasePage_ExtractWebPartDocumentViaWebServicesFromWebPartPageTest()
+        {
+            string url = "/sites/teamsite/SitePages/WPP-2010-Quantum.aspx";
+            //string url = "/pages/article-2010-custom.aspx";
+
+            using (var context = TestCommon.CreateOnPremisesClientContext(TestCommon.AppSetting("SPOnPremTeamSiteUrl")))
+            {
+
+                var pages = context.Web.GetPages("WPP-2010-Quantum");
+
+                pages.FailTestIfZero();
+
+                foreach (var page in pages)
+                {
+                    page.EnsureProperties(p => p.File);
+
+                    List<string> search = new List<string>()
+                    {
+                        "WebPartZone"
+                    };
+
+                    //Should be one
+                    TestBasePage testBase = new TestBasePage(page, page.File, null, null);
+                    var result = testBase.ExtractWebPartDocumentViaWebServicesFromPage(url);
+
+                    Assert.IsTrue(result.Item1.Length > 0);
+                    Assert.IsTrue(result.Item2.Length > 0);
+
+                    break;
+
+                }
+            }
+
+        }
+
 
         [TestMethod]
         public void BasePage_LoadWebPartPropertiesViaWebServicesTest()

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
@@ -10,7 +10,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
     public class OnPremisesWebPartPageTests
     {
         [TestMethod]
-        public void BasicOnPremWikiPageTest()
+        public void OnPremises_BasicWikiPageTest()
         {
             using (var targetClientContext = TestCommon.CreateClientContext(TestCommon.AppSetting("SPOTargetSiteUrl")))
             {
@@ -68,5 +68,22 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
             }
 
         }
+
+        [TestMethod]
+        public void OnPremises_WebExtensions_GetSitePages()
+        {
+            using (var sourceClientContext = TestCommon.CreateOnPremisesClientContext(TestCommon.AppSetting("SPOnPremTeamSiteUrl")))
+            {
+
+                var result = sourceClientContext.Web.GetSitePagesLibrary();
+
+                Assert.IsNotNull(result);
+                Assert.AreNotEqual(default(List), result);
+
+            }
+        }
+
     }
+
+    
 }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.SharePoint.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharePointPnP.Modernization.Framework.Telemetry.Observers;
+using SharePointPnP.Modernization.Framework.Transform;
+
+namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
+{
+    [TestClass]
+    public class OnPremisesWebPartPageTests
+    {
+        [TestMethod]
+        public void BasicOnPremWikiPageTest()
+        {
+            using (var targetClientContext = TestCommon.CreateClientContext(TestCommon.AppSetting("SPOTargetSiteUrl")))
+            {
+                using (var sourceClientContext = TestCommon.CreateOnPremisesClientContext(TestCommon.AppSetting("SPOnPremTeamSiteUrl")))
+                {
+                    var pageTransformator = new PageTransformator(sourceClientContext, targetClientContext);
+                    pageTransformator.RegisterObserver(new MarkdownObserver(folder: "c:\\temp", includeVerbose: true));
+                    pageTransformator.RegisterObserver(new UnitTestLogObserver());
+
+                    var pages = sourceClientContext.Web.GetPages("WPP-2010-BasicTest");
+                    
+                    pages.FailTestIfZero();
+
+                    foreach (var page in pages)
+                    {
+                        PageTransformationInformation pti = new PageTransformationInformation(page)
+                        {
+                            // If target page exists, then overwrite it
+                            Overwrite = true,
+
+                            // Don't log test runs
+                            SkipTelemetry = true,
+
+                            //Permissions are unlikely to work given cross domain
+                            KeepPageSpecificPermissions = false,
+
+                            //RemoveEmptySectionsAndColumns = false,
+
+                            // Configure the page header, empty value means ClientSidePageHeaderType.None
+                            //PageHeader = new ClientSidePageHeader(cc, ClientSidePageHeaderType.None, null),
+
+                            // Replace embedded images and iframes with a placeholder and add respective images and video web parts at the bottom of the page
+                            // HandleWikiImagesAndVideos = false,
+
+                            // Callout to your custom code to allow for title overriding
+                            //PageTitleOverride = titleOverride,
+
+                            // Callout to your custom layout handler
+                            //LayoutTransformatorOverride = layoutOverride,
+
+                            // Callout to your custom content transformator...in case you fully want replace the model
+                            //ContentTransformatorOverride = contentOverride,
+                            //SkipUrlRewrite = true
+                        };
+
+                        pti.MappingProperties["SummaryLinksToQuickLinks"] = "true";
+                        pti.MappingProperties["UseCommunityScriptEditor"] = "true";
+
+                        var result = pageTransformator.Transform(pti);
+                    }
+
+                    pageTransformator.FlushObservers();
+
+                }
+            }
+
+        }
+    }
+}

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
@@ -49,6 +49,41 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
         }
 
         [TestMethod]
+        public void BasePage_ExtractWebPartPropertiesViaWebServicesFromWikiPageTest()
+        {
+            string url = "/sites/teamsite/SitePages/WKP-2010-Quantum.aspx";
+            //string url = "/pages/article-2010-custom.aspx";
+
+            using (var context = TestCommon.CreateOnPremisesClientContext(TestCommon.AppSetting("SPOnPremTeamSiteUrl")))
+            {
+
+                var pages = context.Web.GetPages("WKP-2010-Quantum");
+
+                pages.FailTestIfZero();
+
+                foreach (var page in pages)
+                {
+                    page.EnsureProperties(p => p.File);
+
+                    List<string> search = new List<string>()
+                    {
+                        "WebPartZone"
+                    };
+
+                    //Should be one
+                    TestBasePage testBase = new TestBasePage(page, page.File, null, null);
+                    var result = testBase.ExtractWebPartPropertiesViaWebServicesFromPage(url);
+
+                    Assert.IsTrue(result.Length > 0);
+
+                    break;
+
+                }
+            }
+
+        }
+
+        [TestMethod]
         public void BasePage_ExtractWebPartPropertiesViaWebServicesFromPageTest()
         {
             string url = "/sites/teamsite/SitePages/WPP-2010-Quantum.aspx";

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/UnitTestLogObserver.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/UnitTestLogObserver.cs
@@ -19,8 +19,9 @@ namespace SharePointPnP.Modernization.Framework.Tests
         {
             var error = entry.Exception != null ? entry.Exception.Message : "No error logged";
             Console.WriteLine($"ERROR: {entry.Heading} Message: {entry.Message} \n\t Source: {entry.Source}, Error: { error }");
+            Console.WriteLine($"ERROR: Stack Trace: {entry.Exception.StackTrace}");
 
-            if(entry.IsCriticalException)
+            if (entry.IsCriticalException)
             {
                 Assert.Fail(entry.Message);
             }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Entities/WebServiceWebPartProperties.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Entities/WebServiceWebPartProperties.cs
@@ -22,6 +22,8 @@ namespace SharePointPnP.Modernization.Framework.Entities
         
         public Dictionary<string, string> Properties { get; set; }
 
+        public string ZoneId { get; set; }
+
         /// <summary>
         /// Shortened web part type name
         /// </summary>

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Entities/WebServiceWebPartProperties.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Entities/WebServiceWebPartProperties.cs
@@ -11,14 +11,16 @@ namespace SharePointPnP.Modernization.Framework.Entities
     {
         public WebServiceWebPartProperties()
         {
-            this.Properties = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
+            this.Properties = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
         }
 
         public string Type { get; set; }
         
         public Guid Id { get; set; }
+
+        public string ControlId { get; set; }
         
-        public Dictionary<string, object> Properties { get; set; }
+        public Dictionary<string, string> Properties { get; set; }
 
         /// <summary>
         /// Shortened web part type name
@@ -34,6 +36,18 @@ namespace SharePointPnP.Modernization.Framework.Entities
             }
 
             return $"{name}";
+        }
+
+        public Dictionary<string, object> PropertiesAsStringObjectDictionary()
+        {
+            Dictionary<string, object> castedCollection = new Dictionary<string, object>();
+
+            foreach (var item in this.Properties)
+            {
+                castedCollection.Add(item.Key, (object)item.Value);
+            }
+
+            return castedCollection;
         }
 
     }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Extensions/WebExtensions.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Extensions/WebExtensions.cs
@@ -482,5 +482,20 @@ namespace Microsoft.SharePoint.Client
 
             return string.Empty;
         }
+
+        /// <summary>
+        /// Gets site pages library from web
+        /// </summary>
+        /// <param name="web"></param>
+        /// <returns></returns>
+        public static List GetSitePagesLibrary(this Web web)
+        {
+            //TemplateFeatureId - 00bfea71-c796-4402-9f2f-0eb9a6e71b18
+            var lists = web.Lists;
+            web.Context.Load(lists, list => list.Where(l => l.RootFolder.Name == "SitePages").Include(l => l.Id));
+            web.Context.ExecuteQuery();
+
+            return lists.SingleOrDefault();
+        }
     }
 }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
@@ -34,7 +34,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
             public int Column { get; set; }
             public int Order { get; set; }
             public WebPartDefinition WebPartDefinition { get; set; }
-            public string WebPartXml2010 { get; set; }
+            public string WebPartXmlOnPremises { get; set; }
             public ClientResult<string> WebPartXml { get; set; }
 
             public string WebPartType { get; set; }

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
@@ -617,10 +617,18 @@ namespace SharePointPnP.Modernization.Framework.Pages
 
             if (isLegacy)
             {
+                // Content Editor Web Part
                 string[] contentEditorWebPart = new string[] { "Content", "ContentLink", "PartStorage" };
                 if (CheckWebPartProperties(contentEditorWebPart, properties))
                 {
                     return WebParts.ContentEditor;
+                }
+
+                // Image Viewer Web Part
+                string[] imageViewerWebPart = new string[] { "ImageLink", "AlternativeText", "VerticalAlignment", "HorizontalAlignment" };
+                if (CheckWebPartProperties(imageViewerWebPart, properties))
+                {
+                    return WebParts.Image;
                 }
             }
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
@@ -452,7 +452,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// </summary>
         /// <param name="properties">Web part properties to analyze</param>
         /// <returns>Type of the web part as fully qualified name</returns>
-        public string GetTypeFromProperties(Dictionary<string, object> properties)
+        public string GetTypeFromProperties(Dictionary<string, object> properties, bool isLegacy = false)
         {
             // Check for XSLTListView web part
             string[] xsltWebPart = new string[] { "ListUrl", "ListId", "Xsl", "JSLink", "ShowTimelineIfAvailable" };
@@ -508,6 +508,15 @@ namespace SharePointPnP.Modernization.Framework.Pages
             if (CheckWebPartProperties(addinPartWebPart, properties))
             {
                 return WebParts.Client;
+            }
+
+            if (isLegacy)
+            {
+                string[] contentEditorWebPart = new string[] { "Content", "ContentLink", "PartStorage" };
+                if (CheckWebPartProperties(contentEditorWebPart, properties))
+                {
+                    return WebParts.ContentEditor;
+                }
             }
 
             // check for Script Editor web part

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPageOnPremises.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPageOnPremises.cs
@@ -237,7 +237,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
             webPartsViaManager = cc.LoadQuery(limitedWPManager.WebParts.IncludeWithDefaultProperties(wp => wp.Id, wp => wp.WebPart.Title, wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden));
             cc.ExecuteQueryRetry();
 
-            webServiceWebPartEntities = LoadWebPartPageFromWebServices(publishingPage.EnsureProperty(p=>p.ServerRelativeUrl));
+            webServiceWebPartEntities = LoadPublishingPageFromWebServices(publishingPage.EnsureProperty(p=>p.ServerRelativeUrl));
            
 
             if (webPartsViaManager.Count() > 0)

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPageOnPremises.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPageOnPremises.cs
@@ -292,7 +292,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
                     if (!isExportable)
                     {
                         // Use different approach to determine type as we can't export the web part XML without indroducing a change
-                        foundWebPart.WebPartType = GetTypeFromProperties(webPartProperties);
+                        foundWebPart.WebPartType = GetTypeFromProperties(webPartProperties, true);
                     }
                     else
                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPage.cs
@@ -30,7 +30,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// </summary>
         /// <param name="includeTitleBarWebPart">Include the TitleBar web part</param>
         /// <returns>Information about the analyzed webpart page</returns>
-        public Tuple<PageLayout, List<WebPartEntity>> Analyze(bool includeTitleBarWebPart = false)
+        public virtual Tuple<PageLayout, List<WebPartEntity>> Analyze(bool includeTitleBarWebPart = false)
         {
             List<WebPartEntity> webparts = new List<WebPartEntity>();
 
@@ -150,7 +150,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// <param name="zoneId">Web part zone id</param>
         /// <param name="layout">Layout of the web part page</param>
         /// <returns>Column value</returns>
-        private int GetColumn(string zoneId, PageLayout layout)
+        internal int GetColumn(string zoneId, PageLayout layout)
         {
             switch (layout)
             {
@@ -300,7 +300,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// <param name="zoneId">Web part zone id</param>
         /// <param name="layout">Layout of the web part page</param>
         /// <returns>Row value</returns>
-        private int GetRow(string zoneId, PageLayout layout)
+        internal int GetRow(string zoneId, PageLayout layout)
         {
             switch (layout)
             {
@@ -467,7 +467,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// </summary>
         /// <param name="pageProperties">Properties of the web part page file</param>
         /// <returns>Used layout</returns>
-        private PageLayout GetLayout(PropertyValues pageProperties)
+        internal PageLayout GetLayout(PropertyValues pageProperties)
         {
             if (pageProperties.FieldValues.ContainsKey("vti_setuppath"))
             {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPageOnPremises.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPageOnPremises.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client.WebParts;
+using SharePointPnP.Modernization.Framework.Entities;
+using SharePointPnP.Modernization.Framework.Extensions;
+
+namespace SharePointPnP.Modernization.Framework.Pages
+{
+    public class WebPartPageOnPremises : WebPartPage
+    {
+
+        #region construction
+        /// <summary>
+        /// Instantiates a web part page object for on-premises environments
+        /// </summary>
+        /// <param name="page">ListItem holding the page to analyze</param>
+        /// <param name="pageFile">File holding the page (for pages living outside of a library)</param>
+        /// <param name="pageTransformation">Page transformation information</param>
+        public WebPartPageOnPremises(ListItem page, File pageFile, PageTransformation pageTransformation) : base(page, pageFile, pageTransformation)
+        {
+        }
+        #endregion
+
+
+        /// <summary>
+        /// Analyses a webpart page from on-premises environment
+        /// </summary>
+        /// <param name="includeTitleBarWebPart"></param>
+        /// <returns></returns>
+        public override Tuple<PageLayout, List<WebPartEntity>> Analyze(bool includeTitleBarWebPart = false)
+        {
+            List<WebPartEntity> webparts = new List<WebPartEntity>();
+
+            //Load the page
+            string webPartPageUrl = null;
+            File webPartPage = null;
+
+            if (this.page != null)
+            {
+                webPartPageUrl = page[Constants.FileRefField].ToString();
+                webPartPage = cc.Web.GetFileByServerRelativeUrl(webPartPageUrl);
+            }
+            else
+            {
+                webPartPageUrl = this.pageFile.EnsureProperty(p => p.ServerRelativeUrl);
+                webPartPage = this.pageFile;
+            }
+
+            // Load web parts on web part page
+            // Note: Web parts placed outside of a web part zone using SPD are not picked up by the web part manager. There's no API that will return those,
+            //       only possible option to add parsing of the raw page aspx file.
+            var limitedWPManager = webPartPage.GetLimitedWebPartManager(PersonalizationScope.Shared);
+            cc.Load(limitedWPManager);
+            
+            IEnumerable<WebPartDefinition> webParts = cc.LoadQuery(limitedWPManager.WebParts.IncludeWithDefaultProperties(wp => wp.Id, wp => wp.WebPart.Title, wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden));
+            cc.ExecuteQueryRetry();
+
+            List<WebServiceWebPartProperties> webServiceWebPartEntities = LoadWebPartPropertiesFromWebServices(webPartPage.EnsureProperty(p => p.ServerRelativeUrl)); ;
+            var pageUrl = page[Constants.FileRefField].ToString();
+
+            // Check page type
+            var layout = GetLayoutFromWebServices(webPartPageUrl);
+
+            if (webParts.Count() > 0)
+            {
+                List<WebPartPlaceHolder> webPartsToRetrieve = new List<WebPartPlaceHolder>();
+
+                foreach (var foundWebPart in webParts)
+                {
+                    webPartsToRetrieve.Add(new WebPartPlaceHolder()
+                    {
+                        WebPartDefinition = foundWebPart,
+                        WebPartXml = null,
+                        WebPartType = "",
+                    });
+                }
+
+                
+                foreach (var foundWebPart in webPartsToRetrieve)
+                {
+                    var wsWp = webServiceWebPartEntities.FirstOrDefault(o => o.Id == foundWebPart.WebPartDefinition.Id);
+
+                    // Skip Microsoft.SharePoint.WebPartPages.TitleBarWebPart webpart in TitleBar zone
+                    if (wsWp.ZoneId.Equals("TitleBar", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        if (!includeTitleBarWebPart)
+                        {
+                            continue;
+                        }
+                    }
+
+                    var wsExportMode = wsWp.Properties.FirstOrDefault(o => o.Key.Equals("exportmode", StringComparison.InvariantCultureIgnoreCase));
+
+                    if (!string.IsNullOrEmpty(wsExportMode.Value) && wsExportMode.Value.Equals("all", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        var webPartXml = ExportWebPartXmlWorkaround(pageUrl, foundWebPart.WebPartDefinition.Id.ToString());
+                        foundWebPart.WebPartXmlOnPremises = webPartXml;
+                    }
+                }
+                
+
+                foreach (var foundWebPart in webPartsToRetrieve)
+                {
+                    bool isExportable = false;
+                    Dictionary<string, object> webPartProperties = null;
+
+                    var wsWp = webServiceWebPartEntities.FirstOrDefault(o => o.Id == foundWebPart.WebPartDefinition.Id);
+                    webPartProperties = wsWp.PropertiesAsStringObjectDictionary();
+
+                    // Skip Microsoft.SharePoint.WebPartPages.TitleBarWebPart webpart in TitleBar zone
+                    if (wsWp.ZoneId.Equals("TitleBar", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        if (!includeTitleBarWebPart)
+                        {
+                            continue;
+                        }
+                    }
+
+                    // If the web service call includes the export mode value then set the export options
+                    var wsExportMode = wsWp.Properties.FirstOrDefault(o => o.Key.Equals("exportmode", StringComparison.InvariantCultureIgnoreCase));
+
+                    if (!string.IsNullOrEmpty(wsExportMode.Value) && wsExportMode.Value.ToString().Equals("all", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        isExportable = true;
+                    }
+
+                    if (!isExportable)
+                    {
+                        // Use different approach to determine type as we can't export the web part XML without indroducing a change
+                        foundWebPart.WebPartType = GetTypeFromProperties(webPartProperties, true);
+                    }
+                    else
+                    {
+                        foundWebPart.WebPartType = GetType(foundWebPart.WebPartXmlOnPremises);
+                    }
+
+                    webparts.Add(new WebPartEntity()
+                    {
+                        Title = foundWebPart.WebPartDefinition.WebPart.Title,
+                        Type = foundWebPart.WebPartType,
+                        Id = foundWebPart.WebPartDefinition.Id,
+                        ServerControlId = foundWebPart.WebPartDefinition.Id.ToString(),
+                        Row = GetRow(wsWp.ZoneId, layout),
+                        Column = GetColumn(wsWp.ZoneId, layout),
+                        Order = foundWebPart.WebPartDefinition.WebPart.ZoneIndex,
+                        ZoneId = wsWp.ZoneId,
+                        ZoneIndex = (uint)foundWebPart.WebPartDefinition.WebPart.ZoneIndex,
+                        IsClosed = foundWebPart.WebPartDefinition.WebPart.IsClosed,
+                        Hidden = foundWebPart.WebPartDefinition.WebPart.Hidden,
+                        Properties = Properties(webPartProperties, foundWebPart.WebPartType, foundWebPart.WebPartXmlOnPremises),
+                    });
+                }
+            }
+
+            return new Tuple<PageLayout, List<WebPartEntity>>(layout, webparts);
+        }
+
+        /// <summary>
+        /// Gets and parses the layout from the web services URL
+        /// </summary>
+        /// <param name="webPartPageUrl"></param>
+        /// <returns></returns>
+        internal PageLayout GetLayoutFromWebServices(string webPartPageUrl)
+        {
+            var wsPageDocument = ExtractWebPartDocumentViaWebServicesFromPage(webPartPageUrl);
+
+            if (!string.IsNullOrEmpty(wsPageDocument.Item1))
+            {
+                //Example fragment from WS
+                //<li>vti_setuppath
+                //<li>SR|1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd2.aspx
+                //<li>vti_generator
+
+                var fullDocument = wsPageDocument.Item1;
+
+                if (!string.IsNullOrEmpty(fullDocument))
+                {
+                    if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd1.aspx"))
+                    {
+                        return PageLayout.WebPart_FullPageVertical;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd2.aspx"))
+                    {
+                        return PageLayout.WebPart_HeaderFooterThreeColumns;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd3.aspx"))
+                    {
+                        return PageLayout.WebPart_HeaderLeftColumnBody;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd4.aspx"))
+                    {
+                        return PageLayout.WebPart_HeaderRightColumnBody;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd5.aspx"))
+                    {
+                        return PageLayout.WebPart_HeaderFooter2Columns4Rows;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd6.aspx"))
+                    {
+                        return PageLayout.WebPart_HeaderFooter4ColumnsTopRow;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd7.aspx"))
+                    {
+                        return PageLayout.WebPart_LeftColumnHeaderFooterTopRow3Columns;
+                    }
+                    else if (fullDocument.ContainsIgnoringCasing(@"1033&#92;STS&#92;doctemp&#92;smartpgs&#92;spstd8.aspx"))
+                    {
+                        return PageLayout.WebPart_RightColumnHeaderFooterTopRow3Columns;
+                    }
+                }
+
+            }
+
+            return PageLayout.WebPart_Custom;
+        }
+    }
+}

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WikiPage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WikiPage.cs
@@ -4,6 +4,7 @@ using AngleSharp.Parser.Html;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.WebParts;
 using SharePointPnP.Modernization.Framework.Entities;
+using SharePointPnP.Modernization.Framework.Transform;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -85,7 +86,14 @@ namespace SharePointPnP.Modernization.Framework.Pages
             // Bulk load the needed web part information
             if (webPartsToRetrieve.Count > 0)
             {
-                LoadWebPartsInWikiContentFromServer(webparts, wikiPage, webPartsToRetrieve);
+                if (GetVersion(cc) == SPVersion.SP2010)
+                {
+                    LoadWebPartsInWikiContentFromOnPremisesServer(webparts, wikiPage, webPartsToRetrieve);
+                }
+                else
+                {
+                    LoadWebPartsInWikiContentFromServer(webparts, wikiPage, webPartsToRetrieve);
+                }    
             }
 
             // Somehow the wiki was not standard formatted, so lets wrap its contents in a text block

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingPageTransformator.cs
@@ -307,7 +307,14 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                 // Grab the pagelayout mapping to use:
                 var pageLayoutMappingModel = GetPageLayoutMappingModel(publishingPageTransformationInformation.SourcePage);
 
-                pageData = new PublishingPage(publishingPageTransformationInformation.SourcePage, pageTransformation, this.publishingPageTransformation, publishingPageTransformationInformation as BaseTransformationInformation, targetContext: targetClientContext, logObservers: base.RegisteredLogObservers).Analyze(pageLayoutMappingModel);
+                if (GetVersion(sourceClientContext) == SPVersion.SP2010)
+                {
+                    pageData = new PublishingPageOnPremises(publishingPageTransformationInformation.SourcePage, pageTransformation, this.publishingPageTransformation, publishingPageTransformationInformation as BaseTransformationInformation, targetContext: targetClientContext, logObservers: base.RegisteredLogObservers).Analyze(pageLayoutMappingModel);
+                }
+                else {
+                    pageData = new PublishingPage(publishingPageTransformationInformation.SourcePage, pageTransformation, this.publishingPageTransformation, publishingPageTransformationInformation as BaseTransformationInformation, targetContext: targetClientContext, logObservers: base.RegisteredLogObservers).Analyze(pageLayoutMappingModel);
+                }
+
 
                 // Wiki content can contain embedded images and videos, which is not supported by the target RTE...split wiki text blocks so the transformator can handle the images and videos as separate web parts
                 LogInfo(LogStrings.WikiTextContainsImagesVideosReferences, LogStrings.Heading_ArticlePageHandling);

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/SharePointPnP.Modernization.Framework.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/SharePointPnP.Modernization.Framework.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Entities\WebServiceWebPartEntity.cs" />
     <Compile Include="Extensions\FileFolderExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Pages\PublishingPageOnPremises.cs" />
     <Compile Include="Publishing\Layouts\PageLayoutHeaderFieldEntity.cs" />
     <Compile Include="Publishing\Layouts\PageLayoutMetadataEntity.cs" />
     <Compile Include="Publishing\Layouts\PageLayoutFieldControlEntity.cs" />

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/SharePointPnP.Modernization.Framework.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/SharePointPnP.Modernization.Framework.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Extensions\FileFolderExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Pages\PublishingPageOnPremises.cs" />
+    <Compile Include="Pages\WebPartPageOnPremises.cs" />
     <Compile Include="Publishing\Layouts\PageLayoutHeaderFieldEntity.cs" />
     <Compile Include="Publishing\Layouts\PageLayoutMetadataEntity.cs" />
     <Compile Include="Publishing\Layouts\PageLayoutFieldControlEntity.cs" />

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -485,7 +485,14 @@ namespace SharePointPnP.Modernization.Framework.Transform
                     {
                         LogInfo($"{LogStrings.TransformSourcePageIsWebPartPage} {LogStrings.TransformSourcePageAnalysing}", LogStrings.Heading_ArticlePageHandling);
 
-                        pageData = new WebPartPage(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation).Analyze(true);
+                        if (GetVersion(sourceClientContext) == SPVersion.SP2010)
+                        {
+                            pageData = new WebPartPageOnPremises(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation).Analyze(true);
+                        }
+                        else
+                        {
+                            pageData = new WebPartPage(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation).Analyze(true);
+                        }
                     }
 
                     // Analyze the "text" parts (wikitext parts and text in content editor web parts)

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -252,6 +252,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 }
 
                 // Need to add further validation for target template
+                targetClientContext.Web.EnsureProperty(o => o.WebTemplate);
                 if (hasTargetContext &&
                    (targetClientContext.Web.WebTemplate != "SITEPAGEPUBLISHING" && targetClientContext.Web.WebTemplate != "STS" && targetClientContext.Web.WebTemplate != "GROUP"))
                 {
@@ -1067,9 +1068,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
             sourceContext.Web.EnsureProperty(w => w.ServerRelativeUrl);
 
             // Load the pages library and page file (if exists) in one go 
-            var listServerRelativeUrl = UrlUtility.Combine(sourceContext.Web.ServerRelativeUrl, "SitePages");
-            
-            pagesLibrary = sourceContext.Web.GetList(listServerRelativeUrl);
+            pagesLibrary = sourceContext.Web.GetSitePagesLibrary(); 
 
             if (pageTransformationInformation.CopyPageMetadata)
             {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/UrlTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/UrlTransformator.cs
@@ -53,7 +53,17 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
             this.sourceSiteUrl = sourceContext.Site.Url;
             this.sourceWebUrl = sourceContext.Web.GetUrl();
-            this.pagesLibrary = CacheManager.Instance.GetPublishingPagesLibraryName(this.sourceContext);
+
+            //TODO: Check Is this always pages and sitePages part of the URL NOT title?
+            if (sourceContext.Web.IsPublishingWeb()) {
+                this.pagesLibrary = CacheManager.Instance.GetPublishingPagesLibraryName(this.sourceContext);
+            }
+            else
+            {
+                this.pagesLibrary = "sitepages";
+            }
+            
+
             this.targetWebUrl = targetContext.Web.GetUrl();
             // Load the URL mapping file
             if (!string.IsNullOrEmpty(baseTransformationInformation?.UrlMappingFile))


### PR DESCRIPTION
Fixes issues with

- Content Editor not transforming
- Split of PublishingPage class to perform OnPremises analysis

Added:

- Some unit test improvements
- Support for 2010 Web Part Pages
- Support for 2010 Wiki Pages

Related to #204 