### PR TITLE
Minor changes - ensure correct usage of EnsureProperty method

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesPublishingPageTests.cs
@@ -132,7 +132,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     List<string> search = new List<string>()
                     {
@@ -167,7 +167,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     List<string> search = new List<string>()
                     {
@@ -202,7 +202,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     //Should be one
                     TestBasePage testBase = new TestBasePage(page, page.File, null, null);

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/OnPremises/OnPremisesWebPartPageTests.cs
@@ -63,7 +63,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     List<string> search = new List<string>()
                     {
@@ -98,7 +98,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     List<string> search = new List<string>()
                     {
@@ -133,7 +133,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     List<string> search = new List<string>()
                     {
@@ -169,7 +169,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.OnPremises
 
                 foreach (var page in pages)
                 {
-                    page.EnsureProperties(p => p.File);
+                    page.EnsureProperty(p => p.File);
 
                     List<string> search = new List<string>()
                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Extensions/WebExtensions.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Extensions/WebExtensions.cs
@@ -137,7 +137,7 @@ namespace Microsoft.SharePoint.Client
         public static List<UserEntity> GetAdmins(this Web web)
         {
             List<UserEntity> adminList = new List<UserEntity>(2);
-            web.EnsureProperties(p => p.SiteUsers);
+            web.EnsureProperty(p => p.SiteUsers);
 
             var admins = web.SiteUsers.Where(p => p.IsSiteAdmin);
             if (admins != null && admins.Count() > 0)
@@ -159,11 +159,11 @@ namespace Microsoft.SharePoint.Client
         public static List<UserEntity> GetOwners(this Web web)
         {
             List<UserEntity> ownerList = new List<UserEntity>();
-            web.EnsureProperties(p => p.AssociatedOwnerGroup);
+            web.EnsureProperty(p => p.AssociatedOwnerGroup);
 
             if (web.AssociatedOwnerGroup != null && !(web.AssociatedOwnerGroup.ServerObjectIsNull == null) && !web.AssociatedOwnerGroup.ServerObjectIsNull.Value)
             {
-                web.AssociatedOwnerGroup.EnsureProperties(p => p.Users);
+                web.AssociatedOwnerGroup.EnsureProperty(p => p.Users);
                 foreach (var owner in web.AssociatedOwnerGroup.Users)
                 {
                     ownerList.Add(new UserEntity() { LoginName = owner.LoginName, Email = owner.Email, Title = owner.Title });
@@ -180,11 +180,11 @@ namespace Microsoft.SharePoint.Client
         public static List<UserEntity> GetMembers(this Web web)
         {
             List<UserEntity> memberList = new List<UserEntity>();
-            web.EnsureProperties(p => p.AssociatedMemberGroup);
+            web.EnsureProperty(p => p.AssociatedMemberGroup);
 
             if (web.AssociatedMemberGroup != null && !(web.AssociatedMemberGroup.ServerObjectIsNull == null) && !web.AssociatedMemberGroup.ServerObjectIsNull.Value)
             {
-                web.AssociatedMemberGroup.EnsureProperties(p => p.Users);
+                web.AssociatedMemberGroup.EnsureProperty(p => p.Users);
                 foreach (var member in web.AssociatedMemberGroup.Users)
                 {
                     memberList.Add(new UserEntity() { LoginName = member.LoginName, Email = member.Email, Title = member.Title });
@@ -201,11 +201,11 @@ namespace Microsoft.SharePoint.Client
         public static List<UserEntity> GetVisitors(this Web web)
         {
             List<UserEntity> visitorList = new List<UserEntity>();
-            web.EnsureProperties(p => p.AssociatedVisitorGroup);
+            web.EnsureProperty(p => p.AssociatedVisitorGroup);
 
             if (web.AssociatedVisitorGroup != null && !(web.AssociatedVisitorGroup.ServerObjectIsNull == null) && !web.AssociatedVisitorGroup.ServerObjectIsNull.Value)
             {
-                web.AssociatedVisitorGroup.EnsureProperties(p => p.Users);
+                web.AssociatedVisitorGroup.EnsureProperty(p => p.Users);
                 foreach (var visitor in web.AssociatedVisitorGroup.Users)
                 {
                     visitorList.Add(new UserEntity() { LoginName = visitor.LoginName, Email = visitor.Email, Title = visitor.Title });
@@ -237,7 +237,7 @@ namespace Microsoft.SharePoint.Client
 
             if (!usersAreInstantiated)
             {
-                web.SiteGroups.EnsureProperties(p => p.Include(s => s.Users));
+                web.SiteGroups.EnsureProperty(p => p.Include(s => s.Users));
             }
 
             // Check grants via SharePoint groups
@@ -254,7 +254,7 @@ namespace Microsoft.SharePoint.Client
             var everyoneClaims = web.SiteUsers.Where(p => p.LoginName.Equals(claim1, StringComparison.InvariantCultureIgnoreCase) || p.LoginName.Equals(claim2, StringComparison.InvariantCultureIgnoreCase));
             if (everyoneClaims != null && everyoneClaims.Count() > 0)
             {
-                web.EnsureProperties(p => p.RoleAssignments);
+                web.EnsureProperty(p => p.RoleAssignments);
 
                 foreach (var claim in everyoneClaims)
                 {
@@ -454,7 +454,7 @@ namespace Microsoft.SharePoint.Client
             {
                 var siteCtx = web.Context.GetSiteCollectionContext();
                 siteCtx.Site.EnsureProperties(p => p.ServerRelativeUrl, p => p.Url);
-                web.EnsureProperties(p => p.ServerRelativeUrl);
+                web.EnsureProperty(p => p.ServerRelativeUrl);
 
                 var siteUri = new Uri(siteCtx.Site.Url);
                 string host = $"{siteUri.Scheme}://{siteUri.DnsSafeHost}";

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Functions/BuiltIn.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Functions/BuiltIn.cs
@@ -373,13 +373,13 @@ namespace SharePointPnP.Modernization.Framework.Functions
             else
             {
                 var sourceList = this.sourceClientContext.Web.GetListById(listId);
-                sourceList.EnsureProperties(p=>p.Title);
+                sourceList.EnsureProperty(p=>p.Title);
 
                 List targetlist = null;
                 try
                 {
                     targetlist = this.clientContext.Web.GetListByTitle(sourceList.Title);
-                    targetlist.EnsureProperties(p => p.Id);
+                    targetlist.EnsureProperty(p => p.Id);
                 }
                 catch (Exception ex)
                 {
@@ -593,7 +593,7 @@ namespace SharePointPnP.Modernization.Framework.Functions
                 stop = true;
             }
 
-            this.clientContext.Web.EnsureProperties(p => p.ServerRelativeUrl);
+            this.clientContext.Web.EnsureProperty(p => p.ServerRelativeUrl);
 
             // Check if this url is pointing to content living in this site
             if (!stop && !serverRelativeImagePath.StartsWith(this.clientContext.Web.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
@@ -727,7 +727,7 @@ namespace SharePointPnP.Modernization.Framework.Functions
             // Assume document lives in current web
             ClientContext contextToUse = this.clientContext;
 
-            this.clientContext.Web.EnsureProperties(p => p.ServerRelativeUrl);
+            this.clientContext.Web.EnsureProperty(p => p.ServerRelativeUrl);
             if (!serverRelativeUrl.StartsWith(this.clientContext.Web.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
             {
                 try
@@ -910,7 +910,7 @@ namespace SharePointPnP.Modernization.Framework.Functions
                 return "";
             }
 
-            this.clientContext.Web.EnsureProperties(p => p.ServerRelativeUrl);
+            this.clientContext.Web.EnsureProperty(p => p.ServerRelativeUrl);
             if (!contentLink.StartsWith(this.clientContext.Web.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))
             {
                 try

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/ContentByQuerySearchTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/ContentByQuerySearchTransformator.cs
@@ -439,7 +439,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
             cc.Web.EnsureProperties(p => p.Id, p => p.Url);
             cc.Site.EnsureProperties(p => p.Id, p => p.RootWeb);
-            cc.Site.RootWeb.EnsureProperties(p => p.Url);
+            cc.Site.RootWeb.EnsureProperty(p => p.Url);
 
             // Default initialization of the configuration
             this.properties.WebId = cc.Web.Id.ToString();
@@ -1433,7 +1433,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
             }
 
             IEnumerable<Field> foundFields = null;
-            this.clientContext.Web.EnsureProperties(p => p.Fields);
+            this.clientContext.Web.EnsureProperty(p => p.Fields);
 
             if (Guid.TryParse(sortField, out Guid fieldId))
             {
@@ -1468,7 +1468,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
             }
             else
             {
-                this.clientContext.Web.EnsureProperties(p => p.Fields);
+                this.clientContext.Web.EnsureProperty(p => p.Fields);
 
                 if (Guid.TryParse(filterField, out Guid fieldId))
                 {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/QuickLinksTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/QuickLinksTransformator.cs
@@ -485,7 +485,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
             cc.Web.EnsureProperties(p => p.Id, p => p.Url);
             cc.Site.EnsureProperties(p => p.Id, p => p.RootWeb);
-            cc.Site.RootWeb.EnsureProperties(p => p.Url);
+            cc.Site.RootWeb.EnsureProperty(p => p.Url);
         }
         #endregion
 
@@ -758,7 +758,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 stop = true;
             }
 
-            this.clientContext.Web.EnsureProperties(p => p.ServerRelativeUrl);
+            this.clientContext.Web.EnsureProperty(p => p.ServerRelativeUrl);
 
             // Check if this url is pointing to content living in this site
             if (!stop && !serverRelativeFilePath.StartsWith(this.clientContext.Web.ServerRelativeUrl, StringComparison.InvariantCultureIgnoreCase))

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Analyzers/PublishingAnalyzer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Analyzers/PublishingAnalyzer.cs
@@ -107,7 +107,7 @@ namespace SharePoint.Modernization.Scanner.Analyzers
                         Web web = cc.Web;
 
                         // Load additional web properties
-                        web.EnsureProperties(p => p.Language);
+                        web.EnsureProperty(p => p.Language);
                         scanResult.Language = web.Language;
 
                         // PageLayouts handling
@@ -500,7 +500,7 @@ namespace SharePoint.Modernization.Scanner.Analyzers
             var variationLabels = new List<VariationLabelEntity>();
             // Get current web
             Web web = context.Web;
-            web.EnsureProperties(w => w.ServerRelativeUrl);
+            web.EnsureProperty(w => w.ServerRelativeUrl);
 
             // Try to get _VarLabelsListId property from web property bag
             string variationLabelsListId = GetPropertyBagValue<string>(web, VARIATIONLABELSLISTID, string.Empty);
@@ -537,7 +537,7 @@ namespace SharePoint.Modernization.Scanner.Analyzers
 
         private static T GetPropertyBagValue<T>(Web web, string key, T defaultValue)
         {
-            web.EnsureProperties(p => p.AllProperties);
+            web.EnsureProperty(p => p.AllProperties);
             
             if (web.AllProperties.FieldValues.ContainsKey(key))
             {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Extensions/FileExtensions.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Scanner/Extensions/FileExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.SharePoint.Client
             ListScanResult result = new ListScanResult();
 
             // Load properties
-            file.EnsureProperties(p => p.PageRenderType);
+            file.EnsureProperty(p => p.PageRenderType);
 
             // If it works in modern, we're good
             if (file.PageRenderType == ListPageRenderType.Modern)

--- a/Tools/SharePoint.Modernization/TransformationModel.md
+++ b/Tools/SharePoint.Modernization/TransformationModel.md
@@ -136,7 +136,7 @@ namespace SharePoint.Modernization.Framework.SampleAddOn
             else
             {
                 var list = this.clientContext.Web.GetListById(listId);
-                list.EnsureProperties(p => p.RootFolder.ServerRelativeUrl);
+                list.EnsureProperty(p => p.RootFolder.ServerRelativeUrl);
                 return list.RootFolder.ServerRelativeUrl;
             }
         }


### PR DESCRIPTION
Minor changes to the code, changed from `EnsureProperties` to `EnsureProperty`  extension method where necessary.

Saw a lot of places where we are not using it correctly, am also planning to change it in the Core repository as well, hope that's ok :) 
Minor performance improvements since we bypass the unnecessary foreach loop (used internally in the `EnsureProperties` method.