### PR TITLE
Fix: added fix for trailing slash in root site collection

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -278,7 +278,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
                     if (fileRefFieldValue.ToLower().Contains("/sitepages"))
                     {
-                        pageFolder = fileRefFieldValue.Replace($"{sourceClientContext.Web.ServerRelativeUrl}/SitePages", "").Trim();
+                        pageFolder = fileRefFieldValue.Replace($"{sourceClientContext.Web.ServerRelativeUrl.TrimEnd(new[] { '/' })}/SitePages", "").Trim();
                     }
                     else
                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -833,7 +833,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
             {
                 // Source file was living outside of the site pages library
                 targetPath = sourcePath.Replace(sourceClientContext.Web.ServerRelativeUrl, "");
-                targetPath = $"{sourceClientContext.Web.ServerRelativeUrl}/SitePages{targetPath}";
+                targetPath = $"{sourceClientContext.Web.ServerRelativeUrl.TrimEnd(new[] { '/' })}/SitePages{targetPath}";
             }
 
             var sourcePage = this.sourceClientContext.Web.GetFileByServerRelativeUrl(sourcePageUrl);
@@ -1017,13 +1017,13 @@ namespace SharePointPnP.Modernization.Framework.Transform
                         targetPath = targetPath + "root/";
                     }
 
-                    targetPath = $"{targetClientContext.Web.ServerRelativeUrl.ToLower()}/sitepages{targetPath}";
+                    targetPath = $"{targetClientContext.Web.ServerRelativeUrl.TrimEnd(new[] { '/' }).ToLower()}/sitepages{targetPath}";
                 }
                 else
                 {
                     // Page was living inside the sitepages library
-                    targetPath = sourcePath.Replace($"{sourceClientContext.Web.ServerRelativeUrl}/sitepages".ToLower(), "");
-                    targetPath = $"{targetClientContext.Web.ServerRelativeUrl.ToLower()}/sitepages{targetPath}";
+                    targetPath = sourcePath.Replace($"{sourceClientContext.Web.ServerRelativeUrl.TrimEnd(new[] { '/' })}/sitepages".ToLower(), "");
+                    targetPath = $"{targetClientContext.Web.ServerRelativeUrl.TrimEnd(new[] { '/' }).ToLower()}/sitepages{targetPath}";
                 }
 
                 returnUrl = $"{targetPath}{originalSourcePageName}";
@@ -1041,7 +1041,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                         targetPath = targetPath + "root/";
                     }
 
-                    targetPath = $"{sourceClientContext.Web.ServerRelativeUrl}/sitepages{targetPath}".ToLower();
+                    targetPath = $"{sourceClientContext.Web.ServerRelativeUrl.TrimEnd(new[] { '/' })}/sitepages{targetPath}".ToLower();
                 }
 
                 if (!pageTransformationInformation.TargetPageTakesSourcePageName)


### PR DESCRIPTION
Added a minor fix to remove trailing slash from root site collection.
This fixes an edge case issue where I transform the wiki pages or webpart pages from the root site collection (i.e `https://tenant.sharepoint.com`) to another site collection. In the existing setup, it creates a SitePages folder inside the Site Pages library in the destination site collection.