### PR TITLE
Fix for CDN images in OnPrem root site

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
@@ -149,6 +149,18 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 return false;
             }
 
+            // Additional check to see if image is outside SharePoint for OnPrem to Online scenario for root site and subsites in root site collection
+            if (sourceUrl.ContainsIgnoringCasing("https://") || sourceUrl.ContainsIgnoringCasing("http://"))
+            {
+                var sourceBaseUrl = sourceUrl.GetBaseUrl();
+                var sourceCCBaseUrl = _sourceClientContext.Url.GetBaseUrl();
+
+                if (!sourceBaseUrl.Equals(sourceCCBaseUrl, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
             //  Ensure the referenced assets exist within the source site collection
             var sourceSiteContextUrl = _sourceClientContext.Site.EnsureProperty(w => w.ServerRelativeUrl);
 


### PR DESCRIPTION
In a specific scenario for OnPrem to O365 transformation of pages in root site collection, the script simply freezes if the image resides outside SharePoint.

This PR fixes that issue by checking if the base URLs of the images are actually in source SharePoint site collection or not. 

Somehow in Online classic to modern transformation, this works as expected and page is transformed without error, but in OnPrem classic to modern page the code simply freezes in .NET as well as the PnP PowerShell commandlet.

To reproduce, create a simple publishing page in OnPrem root site collection (used blank webpart page layout). 

Add an image from outside SharePoint in the page content field, could be any image located on CDN. I used `https://via.placeholder.com/300/09f/fff.png` this placeholder image.

Try to transform the page to its modern equivalent using .NET or the PowerShell commandlet. 