### PR TITLE
Remove asp prefixes from XML block

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
@@ -1029,8 +1029,12 @@ namespace SharePointPnP.Modernization.Framework.Pages
                 }
 
                 // Clean prefixes
-                xmlBlock = xmlBlock.Replace("__designer:", "Designer");
-                foreach(var prefix in prefixesAndNameSpaces)
+                xmlBlock = xmlBlock
+                    .Replace("__designer:", "Designer")
+                    .Replace("<asp:","<")
+                    .Replace("</asp:","</"); // Remove asp prefixes from xml document
+
+                foreach (var prefix in prefixesAndNameSpaces)
                 {
                     xmlBlock = xmlBlock.Replace($"{prefix.Item1}:", "");
                 }


### PR DESCRIPTION
Minor fix to issue #267, to reproduce, create a data form web part in web part pages, export and import to publishing pages.

Majority of prefixes are dynamically removed based on registered assemblies declared in top of pages. 

This past simple unit test.