### PR TITLE
Changed version request credentials to use clientContext credentials

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/BaseTransform.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/BaseTransform.cs
@@ -194,7 +194,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 {
                     
                     HttpWebRequest request = (HttpWebRequest)WebRequest.Create($"{urlUri.Scheme}://{urlUri.DnsSafeHost}:{urlUri.Port}/_vti_pvt/service.cnf");
-                    request.UseDefaultCredentials = true;
+                    request.Credentials = clientContext.Credentials;
 
                     var response = request.GetResponse();
 


### PR DESCRIPTION
Minor update to have the SP Version Request use the `clientContext.Credentials` instead of the default.

This addresses an issue where authentication sometimes fails to on-premises for cross-site transformation and causes the connection to be classified as SPO (which causes failures).