### PR TITLE
Fix: additional check to determine whether source file exists or not

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
@@ -403,7 +403,9 @@ namespace SharePointPnP.Modernization.Framework.Transform
                                 }
                             }
                         }
+
                     }
+
                 }
             }
             LogWarning(LogStrings.AssetTransferFailedFallback + sourceFileUrl, LogStrings.Heading_AssetTransfer);

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
@@ -406,177 +406,177 @@ namespace SharePointPnP.Modernization.Framework.Transform
                     }
                 }
             }
-            LogWarning(LogStrings.AssetTransferFailedFallback + sourceFileUrl, LogStrings.Heading_AssetTransfer);
+            LogWarning("Asset was not transferred as it was not found in the source web. Asset: " + sourceFileUrl, LogStrings.Heading_AssetTransfer);
             return null;
-        }
-
-        /// <summary>
-        /// Stores an asset transfer reference
-        /// </summary>
-        /// <param name="assetTransferReferenceEntity"></param>
-        /// <param name="update"></param>
-        public void StoreAssetTransferred(AssetTransferredEntity assetTransferredEntity)
-        {
-            // Using the Cache Manager store the asset transfer references
-            // If update - treat the source URL as unique, if multiple web parts reference to this, then it will still refer to the single resource
-            var cache = Cache.CacheManager.Instance;
-            if (!cache.AssetsTransfered.Any(asset =>
-                 string.Equals(asset.TargetAssetTransferredUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase)))
-            {
-                cache.AssetsTransfered.Add(assetTransferredEntity);
             }
 
-        }
-
-        /// <summary>
-        /// Get asset transfer details if they already exist
-        /// </summary>
-        public AssetTransferredEntity GetAssetTransferredIfExists(AssetTransferredEntity assetTransferredEntity)
-        {
-            try
+            /// <summary>
+            /// Stores an asset transfer reference
+            /// </summary>
+            /// <param name="assetTransferReferenceEntity"></param>
+            /// <param name="update"></param>
+            public void StoreAssetTransferred(AssetTransferredEntity assetTransferredEntity)
             {
-                // Using the Cache Manager retrieve asset transfer references (all)
+                // Using the Cache Manager store the asset transfer references
+                // If update - treat the source URL as unique, if multiple web parts reference to this, then it will still refer to the single resource
                 var cache = Cache.CacheManager.Instance;
-
-                var result = cache.AssetsTransfered.SingleOrDefault(
-                    asset => string.Equals(asset.TargetAssetFolderUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase) &&
-                    string.Equals(asset.SourceAssetUrl, assetTransferredEntity.SourceAssetUrl, StringComparison.InvariantCultureIgnoreCase));
-
-                // Return the cached details if found, if not return original search 
-                return result != default(AssetTransferredEntity) ? result : assetTransferredEntity;
-            }
-            catch (Exception ex)
-            {
-                LogError(LogStrings.Error_AssetTransferCheckingIfAssetExists, LogStrings.Heading_AssetTransfer, ex);
-            }
-
-            // Fallback in case of error - this will trigger a transfer of the asset
-            return assetTransferredEntity;
-
-        }
-
-        /// <summary>
-        /// Converts the file name into a friendly format
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
-        public string ConvertFileToFolderFriendlyName(string fileName)
-        {
-            // This is going to need some heavy testing
-            var justFileName = Path.GetFileNameWithoutExtension(fileName);
-            var friendlyName = justFileName.Replace(" ", "-");
-            return friendlyName;
-        }
-
-
-        /// <summary>
-        /// Ensures that we have context of the source site collection
-        /// </summary>
-        internal void EnsureAssetContextIfRequired(string sourceUrl)
-        {
-            EnsureAssetContextIfRequired(_sourceClientContext, sourceUrl);
-        }
-
-
-        /// <summary>
-        /// Ensures that we have context of the source site collection
-        /// </summary>
-        /// <param name="context">Source site context</param>
-        internal void EnsureAssetContextIfRequired(ClientContext context, string sourceUrl)
-        {
-            // There is two scenarios to check
-            //  - If the asset resides on the root site collection
-            //  - If the asset resides on another subsite
-            //  - If the asset resides on a subsite below this context
-
-            try
-            {
-                context.Site.EnsureProperties(o => o.ServerRelativeUrl, o => o.Url, o => o.RootWeb.Id);
-                context.Web.EnsureProperties(o => o.ServerRelativeUrl, o => o.Id);
-
-                string match = string.Empty;
-
-                // Break the URL into segments and deteremine which URL detects the file in the structure.
-                // Use Web IDs to validate content isnt the same on the root
-
-                var fullSiteCollectionUrl = context.Site.Url;
-                var relativeSiteCollUrl = context.Site.ServerRelativeUrl;
-                var sourceCtxUrl = context.Web.GetUrl();
-
-                // Lets break into segments
-                var fileName = Path.GetFileName(sourceUrl);
-
-                // Could already be relative
-                //var sourceUrlWithOutBaseAddr = sourceUrl.Replace(fullSiteCollectionUrl, "").Replace(relativeSiteCollUrl,"");
-                var urlSegments = sourceUrl.Split('/');
-
-                // Need null tests
-                var filteredUrlSegments = urlSegments.Where(o => !string.IsNullOrEmpty(o) && o != fileName).Reverse();
-
-                //Assume the last segment is the filename
-                //Assume the segment before the last is either a folder or library
-
-                //Url to strip back until detected as subweb
-                var remainingUrl = sourceUrl.Replace(fileName, ""); //remove file name
-
-                //Urls to try to determine web
-                foreach (var segment in filteredUrlSegments) //Assume the segment before the last is either a folder or library
+                if (!cache.AssetsTransfered.Any(asset =>
+                     string.Equals(asset.TargetAssetTransferredUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    try
+                    cache.AssetsTransfered.Add(assetTransferredEntity);
+                }
+
+            }
+
+            /// <summary>
+            /// Get asset transfer details if they already exist
+            /// </summary>
+            public AssetTransferredEntity GetAssetTransferredIfExists(AssetTransferredEntity assetTransferredEntity)
+            {
+                try
+                {
+                    // Using the Cache Manager retrieve asset transfer references (all)
+                    var cache = Cache.CacheManager.Instance;
+
+                    var result = cache.AssetsTransfered.SingleOrDefault(
+                        asset => string.Equals(asset.TargetAssetFolderUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase) &&
+                        string.Equals(asset.SourceAssetUrl, assetTransferredEntity.SourceAssetUrl, StringComparison.InvariantCultureIgnoreCase));
+
+                    // Return the cached details if found, if not return original search 
+                    return result != default(AssetTransferredEntity) ? result : assetTransferredEntity;
+                }
+                catch (Exception ex)
+                {
+                    LogError(LogStrings.Error_AssetTransferCheckingIfAssetExists, LogStrings.Heading_AssetTransfer, ex);
+                }
+
+                // Fallback in case of error - this will trigger a transfer of the asset
+                return assetTransferredEntity;
+
+            }
+
+            /// <summary>
+            /// Converts the file name into a friendly format
+            /// </summary>
+            /// <param name="fileName"></param>
+            /// <returns></returns>
+            public string ConvertFileToFolderFriendlyName(string fileName)
+            {
+                // This is going to need some heavy testing
+                var justFileName = Path.GetFileNameWithoutExtension(fileName);
+                var friendlyName = justFileName.Replace(" ", "-");
+                return friendlyName;
+            }
+
+
+            /// <summary>
+            /// Ensures that we have context of the source site collection
+            /// </summary>
+            internal void EnsureAssetContextIfRequired(string sourceUrl)
+            {
+                EnsureAssetContextIfRequired(_sourceClientContext, sourceUrl);
+            }
+
+
+            /// <summary>
+            /// Ensures that we have context of the source site collection
+            /// </summary>
+            /// <param name="context">Source site context</param>
+            internal void EnsureAssetContextIfRequired(ClientContext context, string sourceUrl)
+            {
+                // There is two scenarios to check
+                //  - If the asset resides on the root site collection
+                //  - If the asset resides on another subsite
+                //  - If the asset resides on a subsite below this context
+
+                try
+                {
+                    context.Site.EnsureProperties(o => o.ServerRelativeUrl, o => o.Url, o => o.RootWeb.Id);
+                    context.Web.EnsureProperties(o => o.ServerRelativeUrl, o => o.Id);
+
+                    string match = string.Empty;
+
+                    // Break the URL into segments and deteremine which URL detects the file in the structure.
+                    // Use Web IDs to validate content isnt the same on the root
+
+                    var fullSiteCollectionUrl = context.Site.Url;
+                    var relativeSiteCollUrl = context.Site.ServerRelativeUrl;
+                    var sourceCtxUrl = context.Web.GetUrl();
+
+                    // Lets break into segments
+                    var fileName = Path.GetFileName(sourceUrl);
+
+                    // Could already be relative
+                    //var sourceUrlWithOutBaseAddr = sourceUrl.Replace(fullSiteCollectionUrl, "").Replace(relativeSiteCollUrl,"");
+                    var urlSegments = sourceUrl.Split('/');
+
+                    // Need null tests
+                    var filteredUrlSegments = urlSegments.Where(o => !string.IsNullOrEmpty(o) && o != fileName).Reverse();
+
+                    //Assume the last segment is the filename
+                    //Assume the segment before the last is either a folder or library
+
+                    //Url to strip back until detected as subweb
+                    var remainingUrl = sourceUrl.Replace(fileName, ""); //remove file name
+
+                    //Urls to try to determine web
+                    foreach (var segment in filteredUrlSegments) //Assume the segment before the last is either a folder or library
                     {
-                        var testUrl = UrlUtility.Combine(fullSiteCollectionUrl.ToLower(), remainingUrl.ToLower().Replace(relativeSiteCollUrl.ToLower(), ""));
-
-                        //No need to recurse this
-                        var exists = context.WebExistsFullUrl(testUrl);
-
-                        if (exists)
+                        try
                         {
-                            //winner
-                            match = testUrl;
-                            break;
+                            var testUrl = UrlUtility.Combine(fullSiteCollectionUrl.ToLower(), remainingUrl.ToLower().Replace(relativeSiteCollUrl.ToLower(), ""));
+
+                            //No need to recurse this
+                            var exists = context.WebExistsFullUrl(testUrl);
+
+                            if (exists)
+                            {
+                                //winner
+                                match = testUrl;
+                                break;
+                            }
+                            else
+                            {
+                                remainingUrl = remainingUrl.TrimEnd('/').TrimEnd($"{segment}".ToCharArray());
+                            }
                         }
-                        else
+                        catch
                         {
-                            remainingUrl = remainingUrl.TrimEnd('/').TrimEnd($"{segment}".ToCharArray());
+                            // Nope not the right web - Swallow
                         }
                     }
-                    catch
+
+                    // Check if the asset is on the root site collection
+                    if(match == string.Empty)
                     {
-                        // Nope not the right web - Swallow
+                        // Does it contain a relative reference
+                        if (sourceUrl.StartsWith("/") && !sourceUrl.ContainsIgnoringCasing(context.Web.GetUrl()))
+                        {
+                            match = fullSiteCollectionUrl.ToLower();
+                        }
+                    }
+
+                    if (match != string.Empty && !match.Equals(context.Web.GetUrl(), StringComparison.InvariantCultureIgnoreCase))
+                    {
+
+                        _sourceClientContext = context.Clone(match);
+                        LogDebug("Source Context Switched", "EsureAssetContextIfRequired");
                     }
                 }
-
-                // Check if the asset is on the root site collection
-                if (match == string.Empty)
+                catch (Exception ex)
                 {
-                    // Does it contain a relative reference
-                    if (sourceUrl.StartsWith("/") && !sourceUrl.ContainsIgnoringCasing(context.Web.GetUrl()))
-                    {
-                        match = fullSiteCollectionUrl.ToLower();
-                    }
-                }
-
-                if (match != string.Empty && !match.Equals(context.Web.GetUrl(), StringComparison.InvariantCultureIgnoreCase))
-                {
-
-                    _sourceClientContext = context.Clone(match);
-                    LogDebug("Source Context Switched", "EsureAssetContextIfRequired");
+                    LogError(LogStrings.Error_CannotGetSiteCollContext, LogStrings.Heading_AssetTransfer, ex);
                 }
             }
-            catch (Exception ex)
-            {
-                LogError(LogStrings.Error_CannotGetSiteCollContext, LogStrings.Heading_AssetTransfer, ex);
-            }
-        }
 
-        public static void CopyStream(Stream input, Stream output)
-        {
-            byte[] buffer = new byte[16 * 1024];
-            int read;
-            while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+            public static void CopyStream(Stream input, Stream output)
             {
-                output.Write(buffer, 0, read);
+                byte[] buffer = new byte[16 * 1024];
+                int read;
+                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    output.Write(buffer, 0, read);
+                }
             }
         }
     }
-}

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
@@ -403,9 +403,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                                 }
                             }
                         }
-
                     }
-
                 }
             }
             LogWarning(LogStrings.AssetTransferFailedFallback + sourceFileUrl, LogStrings.Heading_AssetTransfer);

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/AssetTransfer.cs
@@ -243,40 +243,44 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
             Stream sourceStream = null;
             var sourceAssetFile = _sourceClientContext.Web.GetFileByServerRelativeUrl(sourceFileUrl);
+            _sourceClientContext.Load(sourceAssetFile, s => s.Exists);
+            _sourceClientContext.ExecuteQueryRetry();
 
-            // Test ByPass
-            //if 2010 then
-
-            if (_sourceContextSPVersion == SPVersion.SP2010)
+            if (sourceAssetFile.Exists)
             {
-                sourceStream = new MemoryStream();
+                // Test ByPass
+                //if 2010 then
 
-                if (_sourceClientContext.HasPendingRequest)
+                if (_sourceContextSPVersion == SPVersion.SP2010)
                 {
+                    sourceStream = new MemoryStream();
+
+                    if (_sourceClientContext.HasPendingRequest)
+                    {
+                        _sourceClientContext.ExecuteQueryRetry();
+                    }
+                    var fileBinary = File.OpenBinaryDirect(_sourceClientContext, sourceFileUrl);
                     _sourceClientContext.ExecuteQueryRetry();
+                    Stream tempSourceStream = fileBinary.Stream;
+
+                    CopyStream(tempSourceStream, sourceStream);
+
+                    //Fix: https://stackoverflow.com/questions/47510815/sharepoint-uploadfile-specified-argument-was-out-of-range-of-valid-values
+                    sourceStream.Seek(0, SeekOrigin.Begin);
+
                 }
-                var fileBinary = File.OpenBinaryDirect(_sourceClientContext, sourceFileUrl);
-                _sourceClientContext.ExecuteQueryRetry();
-                Stream tempSourceStream = fileBinary.Stream;
+                else
+                {
+                    // Get the file from SharePoint
 
-                CopyStream(tempSourceStream, sourceStream);
+                    ClientResult<System.IO.Stream> sourceAssetFileData = sourceAssetFile.OpenBinaryStream();
+                    _sourceClientContext.Load(sourceAssetFile);
+                    _sourceClientContext.ExecuteQueryRetry();
+                    sourceStream = sourceAssetFileData.Value;
 
-                //Fix: https://stackoverflow.com/questions/47510815/sharepoint-uploadfile-specified-argument-was-out-of-range-of-valid-values
-                sourceStream.Seek(0, SeekOrigin.Begin);
+                }
 
-            }
-            else
-            {
-                // Get the file from SharePoint
-
-                ClientResult<System.IO.Stream> sourceAssetFileData = sourceAssetFile.OpenBinaryStream();
-                _sourceClientContext.Load(sourceAssetFile);
-                _sourceClientContext.ExecuteQueryRetry();
-                sourceStream = sourceAssetFileData.Value;
-
-            }
-
-            using (Stream sourceFileStream = sourceStream)
+                using (Stream sourceFileStream = sourceStream)
                 {
 
                     string fileName = sourceAssetFile.EnsureProperty(p => p.Name);
@@ -399,181 +403,180 @@ namespace SharePointPnP.Modernization.Framework.Transform
                                 }
                             }
                         }
-
                     }
-
                 }
+            }
+            LogWarning(LogStrings.AssetTransferFailedFallback + sourceFileUrl, LogStrings.Heading_AssetTransfer);
+            return null;
+        }
 
-                return null;
+        /// <summary>
+        /// Stores an asset transfer reference
+        /// </summary>
+        /// <param name="assetTransferReferenceEntity"></param>
+        /// <param name="update"></param>
+        public void StoreAssetTransferred(AssetTransferredEntity assetTransferredEntity)
+        {
+            // Using the Cache Manager store the asset transfer references
+            // If update - treat the source URL as unique, if multiple web parts reference to this, then it will still refer to the single resource
+            var cache = Cache.CacheManager.Instance;
+            if (!cache.AssetsTransfered.Any(asset =>
+                 string.Equals(asset.TargetAssetTransferredUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                cache.AssetsTransfered.Add(assetTransferredEntity);
             }
 
-            /// <summary>
-            /// Stores an asset transfer reference
-            /// </summary>
-            /// <param name="assetTransferReferenceEntity"></param>
-            /// <param name="update"></param>
-            public void StoreAssetTransferred(AssetTransferredEntity assetTransferredEntity)
+        }
+
+        /// <summary>
+        /// Get asset transfer details if they already exist
+        /// </summary>
+        public AssetTransferredEntity GetAssetTransferredIfExists(AssetTransferredEntity assetTransferredEntity)
+        {
+            try
             {
-                // Using the Cache Manager store the asset transfer references
-                // If update - treat the source URL as unique, if multiple web parts reference to this, then it will still refer to the single resource
+                // Using the Cache Manager retrieve asset transfer references (all)
                 var cache = Cache.CacheManager.Instance;
-                if (!cache.AssetsTransfered.Any(asset =>
-                     string.Equals(asset.TargetAssetTransferredUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    cache.AssetsTransfered.Add(assetTransferredEntity);
-                }
 
+                var result = cache.AssetsTransfered.SingleOrDefault(
+                    asset => string.Equals(asset.TargetAssetFolderUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase) &&
+                    string.Equals(asset.SourceAssetUrl, assetTransferredEntity.SourceAssetUrl, StringComparison.InvariantCultureIgnoreCase));
+
+                // Return the cached details if found, if not return original search 
+                return result != default(AssetTransferredEntity) ? result : assetTransferredEntity;
+            }
+            catch (Exception ex)
+            {
+                LogError(LogStrings.Error_AssetTransferCheckingIfAssetExists, LogStrings.Heading_AssetTransfer, ex);
             }
 
-            /// <summary>
-            /// Get asset transfer details if they already exist
-            /// </summary>
-            public AssetTransferredEntity GetAssetTransferredIfExists(AssetTransferredEntity assetTransferredEntity)
+            // Fallback in case of error - this will trigger a transfer of the asset
+            return assetTransferredEntity;
+
+        }
+
+        /// <summary>
+        /// Converts the file name into a friendly format
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public string ConvertFileToFolderFriendlyName(string fileName)
+        {
+            // This is going to need some heavy testing
+            var justFileName = Path.GetFileNameWithoutExtension(fileName);
+            var friendlyName = justFileName.Replace(" ", "-");
+            return friendlyName;
+        }
+
+
+        /// <summary>
+        /// Ensures that we have context of the source site collection
+        /// </summary>
+        internal void EnsureAssetContextIfRequired(string sourceUrl)
+        {
+            EnsureAssetContextIfRequired(_sourceClientContext, sourceUrl);
+        }
+
+
+        /// <summary>
+        /// Ensures that we have context of the source site collection
+        /// </summary>
+        /// <param name="context">Source site context</param>
+        internal void EnsureAssetContextIfRequired(ClientContext context, string sourceUrl)
+        {
+            // There is two scenarios to check
+            //  - If the asset resides on the root site collection
+            //  - If the asset resides on another subsite
+            //  - If the asset resides on a subsite below this context
+
+            try
             {
-                try
+                context.Site.EnsureProperties(o => o.ServerRelativeUrl, o => o.Url, o => o.RootWeb.Id);
+                context.Web.EnsureProperties(o => o.ServerRelativeUrl, o => o.Id);
+
+                string match = string.Empty;
+
+                // Break the URL into segments and deteremine which URL detects the file in the structure.
+                // Use Web IDs to validate content isnt the same on the root
+
+                var fullSiteCollectionUrl = context.Site.Url;
+                var relativeSiteCollUrl = context.Site.ServerRelativeUrl;
+                var sourceCtxUrl = context.Web.GetUrl();
+
+                // Lets break into segments
+                var fileName = Path.GetFileName(sourceUrl);
+
+                // Could already be relative
+                //var sourceUrlWithOutBaseAddr = sourceUrl.Replace(fullSiteCollectionUrl, "").Replace(relativeSiteCollUrl,"");
+                var urlSegments = sourceUrl.Split('/');
+
+                // Need null tests
+                var filteredUrlSegments = urlSegments.Where(o => !string.IsNullOrEmpty(o) && o != fileName).Reverse();
+
+                //Assume the last segment is the filename
+                //Assume the segment before the last is either a folder or library
+
+                //Url to strip back until detected as subweb
+                var remainingUrl = sourceUrl.Replace(fileName, ""); //remove file name
+
+                //Urls to try to determine web
+                foreach (var segment in filteredUrlSegments) //Assume the segment before the last is either a folder or library
                 {
-                    // Using the Cache Manager retrieve asset transfer references (all)
-                    var cache = Cache.CacheManager.Instance;
-
-                    var result = cache.AssetsTransfered.SingleOrDefault(
-                        asset => string.Equals(asset.TargetAssetFolderUrl, assetTransferredEntity.TargetAssetFolderUrl, StringComparison.InvariantCultureIgnoreCase) &&
-                        string.Equals(asset.SourceAssetUrl, assetTransferredEntity.SourceAssetUrl, StringComparison.InvariantCultureIgnoreCase));
-
-                    // Return the cached details if found, if not return original search 
-                    return result != default(AssetTransferredEntity) ? result : assetTransferredEntity;
-                }
-                catch (Exception ex)
-                {
-                    LogError(LogStrings.Error_AssetTransferCheckingIfAssetExists, LogStrings.Heading_AssetTransfer, ex);
-                }
-
-                // Fallback in case of error - this will trigger a transfer of the asset
-                return assetTransferredEntity;
-
-            }
-
-            /// <summary>
-            /// Converts the file name into a friendly format
-            /// </summary>
-            /// <param name="fileName"></param>
-            /// <returns></returns>
-            public string ConvertFileToFolderFriendlyName(string fileName)
-            {
-                // This is going to need some heavy testing
-                var justFileName = Path.GetFileNameWithoutExtension(fileName);
-                var friendlyName = justFileName.Replace(" ", "-");
-                return friendlyName;
-            }
-
-
-            /// <summary>
-            /// Ensures that we have context of the source site collection
-            /// </summary>
-            internal void EnsureAssetContextIfRequired(string sourceUrl)
-            {
-                EnsureAssetContextIfRequired(_sourceClientContext, sourceUrl);
-            }
-
-
-            /// <summary>
-            /// Ensures that we have context of the source site collection
-            /// </summary>
-            /// <param name="context">Source site context</param>
-            internal void EnsureAssetContextIfRequired(ClientContext context, string sourceUrl)
-            {
-                // There is two scenarios to check
-                //  - If the asset resides on the root site collection
-                //  - If the asset resides on another subsite
-                //  - If the asset resides on a subsite below this context
-
-                try
-                {
-                    context.Site.EnsureProperties(o => o.ServerRelativeUrl, o => o.Url, o => o.RootWeb.Id);
-                    context.Web.EnsureProperties(o => o.ServerRelativeUrl, o => o.Id);
-
-                    string match = string.Empty;
-
-                    // Break the URL into segments and deteremine which URL detects the file in the structure.
-                    // Use Web IDs to validate content isnt the same on the root
-
-                    var fullSiteCollectionUrl = context.Site.Url;
-                    var relativeSiteCollUrl = context.Site.ServerRelativeUrl;
-                    var sourceCtxUrl = context.Web.GetUrl();
-
-                    // Lets break into segments
-                    var fileName = Path.GetFileName(sourceUrl);
-
-                    // Could already be relative
-                    //var sourceUrlWithOutBaseAddr = sourceUrl.Replace(fullSiteCollectionUrl, "").Replace(relativeSiteCollUrl,"");
-                    var urlSegments = sourceUrl.Split('/');
-
-                    // Need null tests
-                    var filteredUrlSegments = urlSegments.Where(o => !string.IsNullOrEmpty(o) && o != fileName).Reverse();
-
-                    //Assume the last segment is the filename
-                    //Assume the segment before the last is either a folder or library
-
-                    //Url to strip back until detected as subweb
-                    var remainingUrl = sourceUrl.Replace(fileName, ""); //remove file name
-
-                    //Urls to try to determine web
-                    foreach (var segment in filteredUrlSegments) //Assume the segment before the last is either a folder or library
+                    try
                     {
-                        try
+                        var testUrl = UrlUtility.Combine(fullSiteCollectionUrl.ToLower(), remainingUrl.ToLower().Replace(relativeSiteCollUrl.ToLower(), ""));
+
+                        //No need to recurse this
+                        var exists = context.WebExistsFullUrl(testUrl);
+
+                        if (exists)
                         {
-                            var testUrl = UrlUtility.Combine(fullSiteCollectionUrl.ToLower(), remainingUrl.ToLower().Replace(relativeSiteCollUrl.ToLower(), ""));
-
-                            //No need to recurse this
-                            var exists = context.WebExistsFullUrl(testUrl);
-
-                            if (exists)
-                            {
-                                //winner
-                                match = testUrl;
-                                break;
-                            }
-                            else
-                            {
-                                remainingUrl = remainingUrl.TrimEnd('/').TrimEnd($"{segment}".ToCharArray());
-                            }
+                            //winner
+                            match = testUrl;
+                            break;
                         }
-                        catch
+                        else
                         {
-                            // Nope not the right web - Swallow
+                            remainingUrl = remainingUrl.TrimEnd('/').TrimEnd($"{segment}".ToCharArray());
                         }
                     }
-
-                    // Check if the asset is on the root site collection
-                    if(match == string.Empty)
+                    catch
                     {
-                        // Does it contain a relative reference
-                        if (sourceUrl.StartsWith("/") && !sourceUrl.ContainsIgnoringCasing(context.Web.GetUrl()))
-                        {
-                            match = fullSiteCollectionUrl.ToLower();
-                        }
-                    }
-
-                    if (match != string.Empty && !match.Equals(context.Web.GetUrl(), StringComparison.InvariantCultureIgnoreCase))
-                    {
-
-                        _sourceClientContext = context.Clone(match);
-                        LogDebug("Source Context Switched", "EsureAssetContextIfRequired");
+                        // Nope not the right web - Swallow
                     }
                 }
-                catch (Exception ex)
+
+                // Check if the asset is on the root site collection
+                if (match == string.Empty)
                 {
-                    LogError(LogStrings.Error_CannotGetSiteCollContext, LogStrings.Heading_AssetTransfer, ex);
+                    // Does it contain a relative reference
+                    if (sourceUrl.StartsWith("/") && !sourceUrl.ContainsIgnoringCasing(context.Web.GetUrl()))
+                    {
+                        match = fullSiteCollectionUrl.ToLower();
+                    }
+                }
+
+                if (match != string.Empty && !match.Equals(context.Web.GetUrl(), StringComparison.InvariantCultureIgnoreCase))
+                {
+
+                    _sourceClientContext = context.Clone(match);
+                    LogDebug("Source Context Switched", "EsureAssetContextIfRequired");
                 }
             }
-
-            public static void CopyStream(Stream input, Stream output)
+            catch (Exception ex)
             {
-                byte[] buffer = new byte[16 * 1024];
-                int read;
-                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    output.Write(buffer, 0, read);
-                }
+                LogError(LogStrings.Error_CannotGetSiteCollContext, LogStrings.Heading_AssetTransfer, ex);
+            }
+        }
+
+        public static void CopyStream(Stream input, Stream output)
+        {
+            byte[] buffer = new byte[16 * 1024];
+            int read;
+            while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                output.Write(buffer, 0, read);
             }
         }
     }
+}


### PR DESCRIPTION
This PR adds additional check to determine if the asset exists in the source site or not. 

Right now, in some of the pages if the asset is not present and we try to transform the page, the process just stops without throwing an error. This is also quite an edge case, but would be good to have this check in place so that the transformation doesn't stop.