### PR TITLE
Fixed multiple log observers

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/Observers/MarkdownObserver.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/Observers/MarkdownObserver.cs
@@ -15,7 +15,7 @@ namespace SharePointPnP.Modernization.Framework.Telemetry.Observers
     {
 
         // Cache the logs between calls
-        private static readonly Lazy<List<Tuple<LogLevel, LogEntry>>> _lazyLogInstance = new Lazy<List<Tuple<LogLevel, LogEntry>>>(() => new List<Tuple<LogLevel, LogEntry>>());
+        private readonly Lazy<List<Tuple<LogLevel, LogEntry>>> _lazyLogInstance = new Lazy<List<Tuple<LogLevel, LogEntry>>>(() => new List<Tuple<LogLevel, LogEntry>>());
         protected bool _includeDebugEntries;
         protected bool _includeVerbose;
         protected DateTime _reportDate;
@@ -69,7 +69,7 @@ namespace SharePointPnP.Modernization.Framework.Telemetry.Observers
         /// <summary>
         /// Get the single List<LogEntry> instance, singleton pattern
         /// </summary>
-        public static List<Tuple<LogLevel, LogEntry>> Logs
+        public List<Tuple<LogLevel, LogEntry>> Logs
         {
             get
             {


### PR DESCRIPTION
Removed static for MarkdownObserver log variables as if you use multiple log observers then the logs will be emptied after flush for first observer has run

Example of code: 

```C#                    pageTransformator.RegisterObserver(new ConsoleObserver(includeDebugEntries: true));
                    pageTransformator.RegisterObserver(new MarkdownObserver(folder: "c:\\Dev\\ModernizationLogs", includeVerbose: true));
                    pageTransformator.RegisterObserver(new MarkdownToSharePointObserver(targetContext, includeVerbose: true));`