### PR TITLE
Fixed for missing logging

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/BasePage.cs
@@ -1021,7 +1021,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
 
             try
             {
-                LogInfo(LogStrings.RetreivingExportWebPartXmlWorkaround, LogStrings.Heading_ContentTransform);
+                LogInfo($"{LogStrings.RetreivingExportWebPartXmlWorkaround} WebPartId: {webPartGuid}", LogStrings.Heading_ContentTransform);
                 string webPartXml = String.Empty;
                 string serverRelativeUrl = cc.Web.EnsureProperty(w => w.ServerRelativeUrl);
                 var uri = new Uri(cc.Site.Url);

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPageOnPremises.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/PublishingPageOnPremises.cs
@@ -34,7 +34,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// </summary>
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageTransformation">Page transformation information</param>
-        public PublishingPageOnPremises(ListItem page, PageTransformation pageTransformation, PublishingPageTransformation publishingPageTransformation, BaseTransformationInformation baseTransformationInformation, ClientContext targetContext = null, IList<ILogObserver> logObservers = null) : base(page, pageTransformation, publishingPageTransformation,  baseTransformationInformation, targetContext, logObservers = null)
+        public PublishingPageOnPremises(ListItem page, PageTransformation pageTransformation, PublishingPageTransformation publishingPageTransformation, BaseTransformationInformation baseTransformationInformation, ClientContext targetContext = null, IList<ILogObserver> logObservers = null) : base(page, pageTransformation, publishingPageTransformation,  baseTransformationInformation, targetContext, logObservers)
         {
 
         }
@@ -255,7 +255,6 @@ namespace SharePointPnP.Modernization.Framework.Pages
             webPartsViaManager = cc.LoadQuery(limitedWPManager.WebParts.IncludeWithDefaultProperties(wp => wp.Id, wp => wp.WebPart.Title, wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden));
             cc.ExecuteQueryRetry();
 
-            LogInfo(LogStrings.TransformUsesWebServicesFallback, LogStrings.Heading_Summary, LogEntrySignificance.WebServiceFallback);
             webServiceWebPartEntities = LoadPublishingPageFromWebServices(publishingPage.EnsureProperty(p=>p.ServerRelativeUrl));
            
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPage.cs
@@ -22,7 +22,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageFile">File holding the page (for pages living outside of a library)</param>
         /// <param name="pageTransformation">Page transformation information</param>
-        public WebPartPage(ListItem page, File pageFile, PageTransformation pageTransformation) : base(page, pageFile, pageTransformation)
+        public WebPartPage(ListItem page, File pageFile, PageTransformation pageTransformation, IList<ILogObserver> logObservers = null) : base(page, pageFile, pageTransformation, logObservers)
         {
         }
         #endregion

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPageOnPremises.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPageOnPremises.cs
@@ -22,7 +22,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageFile">File holding the page (for pages living outside of a library)</param>
         /// <param name="pageTransformation">Page transformation information</param>
-        public WebPartPageOnPremises(ListItem page, File pageFile, PageTransformation pageTransformation) : base(page, pageFile, pageTransformation)
+        public WebPartPageOnPremises(ListItem page, File pageFile, PageTransformation pageTransformation, IList<ILogObserver> logObservers = null) : base(page, pageFile, pageTransformation, logObservers)
         {
         }
         #endregion
@@ -63,6 +63,7 @@ namespace SharePointPnP.Modernization.Framework.Pages
             if (version == Transform.SPVersion.SP2010)
             {
                 // No zoneid and properties properties in 2010 csom
+                LogInfo(LogStrings.TransformUsesWebServicesFallback, LogStrings.Heading_Summary, LogEntrySignificance.WebServiceFallback);
                 webParts = cc.LoadQuery(limitedWPManager.WebParts.IncludeWithDefaultProperties(wp => wp.Id, wp => wp.WebPart.Title, wp => wp.WebPart.ZoneIndex, wp => wp.WebPart.IsClosed, wp => wp.WebPart.Hidden));
             }
             else

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPageOnPremises.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WebPartPageOnPremises.cs
@@ -71,7 +71,6 @@ namespace SharePointPnP.Modernization.Framework.Pages
             }
             cc.ExecuteQueryRetry();
 
-            LogInfo(LogStrings.TransformUsesWebServicesFallback, LogStrings.Heading_Summary, LogEntrySignificance.WebServiceFallback);
             List<WebServiceWebPartProperties> webServiceWebPartEntities = null;
             if (version == Transform.SPVersion.SP2010)
             {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WikiPage.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Pages/WikiPage.cs
@@ -22,7 +22,8 @@ namespace SharePointPnP.Modernization.Framework.Pages
         /// </summary>
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageTransformation">Page transformation information</param>
-        public WikiPage(ListItem page, PageTransformation pageTransformation): base(page, null, pageTransformation)
+        public WikiPage(ListItem page, PageTransformation pageTransformation, IList<ILogObserver> logObservers = null) 
+            : base(page, null, pageTransformation, logObservers)
         {
         }
         #endregion

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/LogStrings.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/LogStrings.cs
@@ -16,8 +16,8 @@
 
         #region Report Text
 
-        public const string Report_ModernisationReport = "Modernisation Report";
-        public const string Report_ModernisationSummaryReport = "Modernisation Summary Report";
+        public const string Report_ModernisationReport = "Modernization Report";
+        public const string Report_ModernisationSummaryReport = "Modernization Summary Report";
         public const string Report_ModernisationPageDetails = "Individual Page details";
         public const string Report_TransformationDetails = "Transformation Details";
         public const string Report_ReportDate = "Report date";
@@ -72,7 +72,7 @@
         public const string Error_BasicASPXPageCannotTransform = "Page is an basic aspx page...can't currently transform that one, sorry!";
         public const string Error_PublishingPagesNotYetSupported = "Page transformation for publishing pages can only be done using the PublishingPageTransformator class";
         public const string Error_DelveBlogPagesNotSupported = "Page transformation for Delve blog pages can only be done using the DelvePageTransformator class";
-        public const string Error_PageIsNotAPublishingPage = "Page is not a publishing page, please use the wiki and webpart page API's";
+        public const string Error_PageIsNotAPublishingPage = "Page is not a publishing page, please use the wiki and web part page API's";
         public const string Error_CannotUsePageAcceptBannerCrossSite = "Page transformation towards a different site collection cannot use the page accept banner.";
         public const string Error_OverridingTagePageTakesSourcePageName = "Overriding 'TargetPageTakesSourcePageName' to ensure that the newly created page in the other site collection gets the same name as the source page";
         public const string Error_FallBackToSameSiteTransfer = "Oops, seems source and target point to the same site collection...switch back the 'source only' mode";
@@ -85,11 +85,11 @@
 
         public const string Error_SettingVersionStampError = "Setting version stamp on page error";
         public const string Error_GetPrincipalFailedEnsureUser = "Failed to ensure user exists";
-        public const string Error_WebPartMappingSchemaValidation = "Provided custom webpart mapping file is invalid: {0}";
+        public const string Error_WebPartMappingSchemaValidation = "Provided custom web part mapping file is invalid: {0}";
         public const string Error_ExtractWebPartPropertiesViaWebServicesFromPage = "Extract Web Part Properties via Web Services from Page failed";
         public const string Error_ExtractWebPartPageViaWebServicesFromPage = "Extract Web Part page via Web Services from Page failed";
         public const string Error_CallingWebServicesToExtractWebPartsFromPage = "Calling Web Services to Extract Web Parts from Page";
-        public const string Error_ExportWebPartXmlWorkaround = "Export WebPart Xml from Web Call failed";
+        public const string Error_ExportWebPartXmlWorkaround = "Export Web Part Xml from Web Call failed";
         public const string Error_AnalyserCouldNotFindLayouts = "GetAllPageLayouts - Could not search for page layouts";
         public const string Error_AnalyserErrorOccurredExtractMetadata = "An issue occurred with extracting metadata from page layout";
         public const string Error_AnalyserErrorOccurredExtractNamespaces = "An error occurred extracting web part prefixes from namespaces";
@@ -189,11 +189,12 @@
 
         public const string SourceSharePointVersion = "Source SharePoint version: ";
         public const string TransformMode = "Mode: ";
-        public const string TransformUsesWebServicesFallback = "Transform using Web Services fallback";
+        public const string TransformUsesWebServicesFallback = "Transform using Web Services";
+        public const string TransformFallback = "Fallback:";
         public const string TransformationModePublishing = "Publishing Page Transformation Mode";
         public const string TransformationMode = "{0} Transformation";
         public const string AnalysingNoWebPartsFound = "No web parts were found on page";
-        public const string ContentTransformFoundSourceWebParts = "Source page contains webpart `{0}` of type `{1}`";
+        public const string ContentTransformFoundSourceWebParts = "Source page contains web part `{0}` of type `{1}`";
         public const string WebPartXmlNotExported = "Xml definition for web part {0} was not exportable. Error {1}.";
 
         #endregion

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/Observers/MarkdownObserver.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Telemetry/Observers/MarkdownObserver.cs
@@ -248,7 +248,7 @@ namespace SharePointPnP.Modernization.Framework.Telemetry.Observers
                                 signifcance = LogStrings.TransformMode;
                                 break;
                             case LogEntrySignificance.WebServiceFallback:
-                                signifcance = LogStrings.TransformUsesWebServicesFallback;
+                                signifcance = LogStrings.TransformFallback;
                                 break;
                         }
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/PageTransformator.cs
@@ -612,14 +612,14 @@ namespace SharePointPnP.Modernization.Framework.Transform
                     {
                         LogInfo($"{LogStrings.TransformSourcePageIsWikiPage} - {LogStrings.TransformSourcePageAnalysing}", LogStrings.Heading_ArticlePageHandling);
 
-                        pageData = new WikiPage(pageTransformationInformation.SourcePage, pageTransformation).Analyze();
+                        pageData = new WikiPage(pageTransformationInformation.SourcePage, pageTransformation, base.RegisteredLogObservers).Analyze();
 
                         // Wiki pages can contain embedded images and videos, which is not supported by the target RTE...split wiki text blocks so the transformator can handle the images and videos as separate web parts
                         LogInfo(LogStrings.WikiTextContainsImagesVideosReferences, LogStrings.Heading_ArticlePageHandling);
                     }
                     else if (IsBlogPage(pageType))
                     {
-                        pageData = new WikiPage(pageTransformationInformation.SourcePage, pageTransformation).Analyze(isBlogPage: true);
+                        pageData = new WikiPage(pageTransformationInformation.SourcePage, pageTransformation, base.RegisteredLogObservers).Analyze(isBlogPage: true);
                     }
                     else if (IsWebPartPage(pageType))
                     {
@@ -627,11 +627,11 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
                         if (spVersion == SPVersion.SP2010 || spVersion == SPVersion.SP2013Legacy || spVersion == SPVersion.SP2016Legacy)
                         {
-                            pageData = new WebPartPageOnPremises(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation).Analyze(true);
+                            pageData = new WebPartPageOnPremises(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation, base.RegisteredLogObservers).Analyze(true);
                         }
                         else
                         {
-                            pageData = new WebPartPage(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation).Analyze(true);
+                            pageData = new WebPartPage(pageTransformationInformation.SourcePage, pageTransformationInformation.SourceFile, pageTransformation, base.RegisteredLogObservers).Analyze(true);
                         }
                     }
 


### PR DESCRIPTION
Reference to issue #420

- Some of the classes missing observers thus could missing out of diag info
- Minor tidy up of log strings

I've not fixed the delve blogs class, markdown output is empty. @jansenbe do we need to fix given its longevity of the feature?