### PR TITLE
More Term mapping fixes

### DIFF
--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/SharePointPnP.Modernization.Framework.Tests.csproj
@@ -257,6 +257,7 @@
     </Content>
     <Content Include="Provision\Publishing\ArticleTopic.aspx" />
     <None Include="Provision\Readme.md" />
+    <None Include="Transform\Mapping\term_mapping_paths_sample.csv" />
     <None Include="Transform\Mapping\term_mapping_sample.csv" />
     <None Include="Transform\Mapping\usermapping_sample.csv" />
     <None Include="Transform\Mapping\urlmapping_sample.csv" />

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Mapping/TermMappingTests.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Mapping/TermMappingTests.cs
@@ -101,6 +101,61 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.Mapping
                             TermMappingFile = @"..\..\Transform\Mapping\term_mapping_sample.csv",
 
                             //Should process default mapping
+                            SkipTermStoreMapping = true,
+
+                            CopyPageMetadata = true
+
+                        };
+
+                        Console.WriteLine("SharePoint Version: {0}", pti.SourceVersion);
+
+                        pti.MappingProperties["SummaryLinksToQuickLinks"] = "true";
+                        pti.MappingProperties["UseCommunityScriptEditor"] = "true";
+
+                        var result = pageTransformator.Transform(pti);
+                    }
+
+                    pageTransformator.FlushObservers();
+
+                }
+            }
+        }
+
+        [TestMethod]
+        public void BasicOnlineWikiPage_DefaultTest()
+        {
+            using (var targetClientContext = TestCommon.CreateClientContext(TestCommon.AppSetting("SPOTargetSiteUrl")))
+            {
+                using (var sourceClientContext = TestCommon.CreateClientContext(TestCommon.AppSetting("SPODevTeamSiteUrl")))
+                {
+                    var pageTransformator = new PageTransformator(sourceClientContext, targetClientContext);
+                    //pageTransformator.RegisterObserver(new MarkdownObserver(folder: "c:\\temp", includeVerbose: true));
+                    pageTransformator.RegisterObserver(new UnitTestLogObserver());
+
+                    var pages = sourceClientContext.Web.GetPagesFromList("Site Pages", pageNameStartsWith: "Common-WikiPageTest");
+
+                    pages.FailTestIfZero();
+
+                    foreach (var page in pages)
+                    {
+                        PageTransformationInformation pti = new PageTransformationInformation(page)
+                        {
+                            // If target page exists, then overwrite it
+                            Overwrite = true,
+
+                            // Don't log test runs
+                            SkipTelemetry = true,
+
+                            //Permissions are unlikely to work given cross domain
+                            KeepPageSpecificPermissions = false,
+
+                            TargetPagePrefix = "DefaultMapping-",
+
+                            SkipUserMapping = true,
+                            SkipDefaultUrlRewrite = true,
+                            SkipUrlRewrite = true,
+
+                            //Should process default mapping
                             SkipTermStoreMapping = false,
 
                             CopyPageMetadata = true
@@ -230,12 +285,12 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.Mapping
             {
                 using (var sourceClientContext = TestCommon.CreateClientContext(TestCommon.AppSetting("SPODevSiteUrl")))
                 {
-                    var pageTransformator = new PublishingPageTransformator(sourceClientContext, targetClientContext, @"C:\temp\onprem-mapping-all-test.xml");
+                    var pageTransformator = new PublishingPageTransformator(sourceClientContext, targetClientContext, @"C:\temp\spo-mapping-all-test.xml");
                     //pageTransformator.RegisterObserver(new MarkdownObserver(folder: "c:\\temp", includeVerbose: true));
                     pageTransformator.RegisterObserver(new UnitTestLogObserver());
 
 
-                    var pages = sourceClientContext.Web.GetPagesFromList("Pages", folder: "News", pageNameStartsWith: "Kitchen");
+                    var pages = sourceClientContext.Web.GetPagesFromList("Pages",  pageNameStartsWith: "Article-PnP-Example");
 
                     pages.FailTestIfZero();
 
@@ -248,9 +303,7 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.Mapping
 
                             // Don't log test runs
                             SkipTelemetry = true,
-
-
-
+                            
                             //Permissions are unlikely to work given cross domain
                             KeepPageSpecificPermissions = false,
 
@@ -282,14 +335,14 @@ namespace SharePointPnP.Modernization.Framework.Tests.Transform.Mapping
             {
                 using (var sourceClientContext = TestCommon.CreateOnPremisesClientContext())
                 {
-                    var pageTransformator = new PublishingPageTransformator(sourceClientContext, targetClientContext, @"C:\temp\onprem-mapping-test-taxonomy.xml");
+                    var pageTransformator = new PublishingPageTransformator(sourceClientContext, targetClientContext, @"C:\temp\onprem-mapping-all-test.xml");
                     //pageTransformator.RegisterObserver(new MarkdownObserver(folder: "c:\\temp", includeVerbose: true));
                     pageTransformator.RegisterObserver(new UnitTestLogObserver(true));
 
                     //2013
-                    //var pages = sourceClientContext.Web.GetPagesFromList("Pages", folder: "News", pageNameStartsWith: "Our-new-IT-suite-is-mint");
+                    var pages = sourceClientContext.Web.GetPagesFromList("Pages", folder: "News", pageNameStartsWith: "Our-new-IT-suite-is-mint");
                     //2010
-                    var pages = sourceClientContext.Web.GetPagesFromList("Pages", pageNameStartsWith: "Article-2010-Taxonomy");
+                    //var pages = sourceClientContext.Web.GetPagesFromList("Pages", pageNameStartsWith: "Article-2010-Taxonomy");
 
                     pages.FailTestIfZero();
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Mapping/term_mapping_paths_sample.csv
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Mapping/term_mapping_paths_sample.csv
@@ -1,0 +1,9 @@
+﻿PnP|Sauce|PnPTransform|On-Premises|Classic Page,PnP|Katchup|PnPTransform|Online|Modern Page
+PnP|Sauce|PnPTransform|On-Premises|Publishing Page,PnP|Katchup|PnPTransform|Online|Modern Page
+PnP|Sauce|PnPTransform|On-Premises|Site Page,PnP|Katchup|PnPTransform|Online|Modern Page
+PnP|Sauce|PnPTransform|On-Premises|Site Page,PnP|Katchup|PnPTransform|From|SharePoint 2013
+
+PnP|Sauce|PnPTransform|On-Premises|SitePages,PnP|Katchup|PnPTransform|From|NodeDoesNotExist
+PnP|Sauce|PnPTransform|On-Premises|NodeDoesNotExist,PnP|Katchup|PnPTransform|From|SharePoint 2013
+
+DEFAULT|Sauce|Team Site|Wiki Page,PnP|Katchup|PnPTransform|From|SharePoint 2010

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Mapping/term_mapping_sample.csv
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework.Tests/Transform/Mapping/term_mapping_sample.csv
@@ -6,6 +6,10 @@ PnP|Sauce|PnPTransform|On-Premises|Site Page,PnP|Katchup|PnPTransform|From|Share
 PnP|Sauce|PnPTransform|On-Premises|SitePages,PnP|Katchup|PnPTransform|From|NodeDoesNotExist
 PnP|Sauce|PnPTransform|On-Premises|NodeDoesNotExist,PnP|Katchup|PnPTransform|From|SharePoint 2013
 
+f0b1b6aa-b00b-4198-b8dd-ef4393e3ad05,fec05391-6a39-4ad5-a2a1-a01020d94efd
+469bf4e8-3f92-4d94-9ebb-034da8917b18,fec05391-6a39-4ad5-a2a1-a01020d94efd
+c578cdb1-910d-4809-88a5-c7e3836eeaa7,fec05391-6a39-4ad5-a2a1-a01020d94efd
+
 2d42d4fa-1dde-45a0-81cc-0bc19acae8db,6558ed84-4a37-46e8-99df-5de2be42f06c
 69475f27-e66a-49d7-8935-f955a187dae5,9be9c990-2a3e-4f68-8ec0-c1e3326586cc
 f6020784-3191-4ae9-993c-e5fd4e2de499,335b95c3-52db-4bda-89be-55e7555fe97b
@@ -19,3 +23,5 @@ ac625b0a-0459-4d23-bc96-0970abd1029d,6558ed84-4a37-46e8-99df-5de2be42f06c
 
 239d84a1-b03a-4300-9a1b-82f95f560f53,6558ed84-4a37-46e8-99df-5de2be42f06c
 abeeb936-3ab9-40ce-aba1-a2e236c915d3,335b95c3-52db-4bda-89be-55e7555fe97b
+04a0448a-e5ed-4476-af89-5e73f25536b1,9be9c990-2a3e-4f68-8ec0-c1e3326586cc
+

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingMetadataTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingMetadataTransformator.cs
@@ -185,7 +185,7 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                                                         sourceSsdId = srcTaxField.SspId;
                                                     }
 
-                                                    bool skipTermMapping = ((sourceTermSetId == targetTaxField.TermSetId) && this.publishingPageTransformationInformation.SkipTermStoreMapping);
+                                                    bool skipTermMapping = ((sourceTermSetId == targetTaxField.TermSetId));
 
                                                     if (!skipTermMapping)
                                                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingMetadataTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Publishing/PublishingMetadataTransformator.cs
@@ -185,7 +185,7 @@ namespace SharePointPnP.Modernization.Framework.Publishing
                                                         sourceSsdId = srcTaxField.SspId;
                                                     }
 
-                                                    bool skipTermMapping = ((sourceTermSetId == targetTaxField.TermSetId));
+                                                    bool skipTermMapping = ((sourceTermSetId == targetTaxField.TermSetId) && string.IsNullOrEmpty(this.publishingPageTransformationInformation.TermMappingFile));
 
                                                     if (!skipTermMapping)
                                                     {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/BasePageTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/BasePageTransformator.cs
@@ -754,7 +754,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                                             }
 
                                             // If source and target field point to the same termset then termmapping is not needed
-                                            bool skipTermMapping = (sourceTermSetId == taxField.TermSetId);
+                                            bool skipTermMapping = ((sourceTermSetId == taxField.TermSetId) && string.IsNullOrEmpty(pageTransformationInformation.TermMappingFile));
 
                                             if (!skipTermMapping)
                                             {

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/TermTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/TermTransformator.cs
@@ -18,10 +18,10 @@ namespace SharePointPnP.Modernization.Framework.Transform
         private ClientContext _sourceContext;
         private ClientContext _targetContext;
         private List<TermMapping> termMappings;
-        private bool skipDefaultTermStoreMapping;
+        private bool skipTermStoreMapping;
         private BaseTransformationInformation _baseTransformationInformation;
         public const string TermNodeDelimiter = "|";
-        public const string TermGroupUnknownName = "FALLBACK";
+        public const string TermGroupUnknownName = "DEFAULT";
 
         #region Construction        
 
@@ -65,7 +65,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
 
             if (baseTransformationInformation != null)
             {
-                this.skipDefaultTermStoreMapping = baseTransformationInformation.SkipTermStoreMapping;
+                this.skipTermStoreMapping = baseTransformationInformation.SkipTermStoreMapping;
                 this._baseTransformationInformation = baseTransformationInformation;
             }
         }
@@ -117,7 +117,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
             // Source or Target Term ID/Name may not be found
                        
             // Default Mode 
-            if (!this.skipDefaultTermStoreMapping && !_baseTransformationInformation.IsCrossFarmTransformation)
+            if (!this.skipTermStoreMapping && !_baseTransformationInformation.IsCrossFarmTransformation)
             {
                 var resolvedInputMapping = ResolveTermInCache(this._sourceContext, inputSourceTerm.TermGuid);
 

--- a/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/TermTransformator.cs
+++ b/Tools/SharePoint.Modernization/SharePointPnP.Modernization.Framework/Transform/TermTransformator.cs
@@ -124,9 +124,8 @@ namespace SharePointPnP.Modernization.Framework.Transform
                 if (resolvedInputMapping.IsTermResolved)
                 {
                     //Check if the source term ID exists in target then map.
-                    //TODO: THe term resolution isnt properly differentiating from source to target.
                     var resolvedInputMappingInTarget = ResolveTermInCache(this._targetContext, inputSourceTerm.TermGuid);
-                    if (resolvedInputMappingInTarget.IsTermResolved)
+                    if (resolvedInputMappingInTarget.IsTermResolved && !resolvedInputMapping.IsSourceTerm)
                     {
                         inputSourceTerm.IsTermResolved = true; //Happy that term ID is the same as source
                         inputSourceTerm.TermLabel = resolvedInputMappingInTarget.TermLabel; //Just in case the ids are the same and labels are not
@@ -136,7 +135,7 @@ namespace SharePointPnP.Modernization.Framework.Transform
                     //Check if the term labels are the same, ids maybe different - in this scenario, validate if the term paths are the same.
                     //if so, then auto-map.
                     resolvedInputMappingInTarget = ResolveTermInCache(this._targetContext, resolvedInputMapping.TermPath);
-                    if (resolvedInputMappingInTarget.IsTermResolved)
+                    if (resolvedInputMappingInTarget.IsTermResolved && !resolvedInputMapping.IsSourceTerm)
                     {
                         inputSourceTerm.IsTermResolved = true; //Happy that term ID is the same as source
                         inputSourceTerm.TermGuid = resolvedInputMappingInTarget.TermGuid; //Just in case the ids are the same and labels are not


### PR DESCRIPTION
- Update to settings/Unknown source group
- Added more tests
- Fixed issue with single source multiple target bug
- If mapping file specified then use that, rather than assume user wants no transform if src/target term sets are the same.

Sorry another merge @jansenbe - there are a lot of scenarios to test for, hopefully I have caught most of them.